### PR TITLE
Properly call pynndescent for querying training data

### DIFF
--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -123,8 +123,8 @@ class NNDescent(KNNIndex):
         )
 
     def query_train(self, data, k):
-        neighbors, distances = self.index.query(data, k=k + 1, queue_size=1)
-        return neighbors[:, 1:], distances[:, 1:]
+        indices, neighbors = self.index._neighbor_graph
+        return indices[:, :k], neighbors[:, :k]
 
     def query(self, query, k):
         return self.index.query(query, k=k, queue_size=1)


### PR DESCRIPTION
##### Issue
When using `pynndescent` for approximate NN search, the index was built, then queried with the training data. Little did I know that I could get the nearest neighbors out of the index as soon as it was built.

##### Description of changes
Properly use pynndescent when querying nearest neighbors for training data.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
