### PR TITLE
Revert nn descent search

### DIFF
--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -123,7 +123,7 @@ class NNDescent(KNNIndex):
         # memory corruption, so use the standard one, which seems to work fine
         self.index = pynndescent.NNDescent(
             data,
-            n_neighbors=k + 1,
+            n_neighbors=15,
             metric=self.metric,
             metric_kwds=self.metric_params,
             random_state=self.random_state,
@@ -133,7 +133,7 @@ class NNDescent(KNNIndex):
             max_candidates=60,
         )
 
-        indices, distances = self.index._neighbor_graph
+        indices, distances = self.index.query(data, k=k + 1, queue_size=1)
         return indices[:, 1:], distances[:, 1:]
 
     def query(self, query, k):


### PR DESCRIPTION
As it turns out, pynndescent appears *faster* when training on the whole data set with the default 15 neighbors, then querying with the remaining e.g. 90 neighbors for perplexity=30.

Further testing needed, but for the time being, the previous method was faster.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
