### PR TITLE
Add scikit-learn API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,25 @@ To squeeze the most out of openTSNE, you may also consider installing FFTW3 prio
  
 ## Usage
 
-We provide two modes of usage. One is somewhat familliar to scikit-learn's `TSNE.fit`.
+We provide two modes of usage as well as a familliar scikit-learn API.
 
-We also provide an advanced interface for finer control of the optimization, allowing us to interactively tune the embedding and make use of various tricks to improve the embedding quality.
+### scikit-learn API
+
+Most users are comfortable with the scikit-learn API so we provide a familliar wrapper to make openTSNE very easy to use.
+
+```python
+from openTSNE.sklearn import TSNE
+from sklearn import datasets
+
+iris = datasets.load_iris()
+x, y = iris["data"], iris["target"]
+
+embedding = TSNE().fit_transform(x)
+```
+
+This interface behaves in much the same way as scikit-learn's t-SNE, but with richer functionality and improved speed. The interface allows us to create arbitrary t-SNE embeddings using the `fit` method and embed new instances into the existing embedding using the `transform` method.
+
+The scikit-learn interface is provides a familliar interface to t-SNE, but in doing so disables some of the more advanced functionality that openTSNE provides such as different affinity models, interactive optimization and callbacks. However, this basic functionality should cover the majority of use cases.
 
 ### Basic usage
 

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -7,6 +7,7 @@ API Reference
     initialization
     affinity
     callbacks
+    sklearn
 
 .. automodule:: openTSNE
     :members: TSNE, TSNEEmbedding, PartialTSNEEmbedding, OptimizationInterrupt

--- a/docs/source/api/sklearn.rst
+++ b/docs/source/api/sklearn.rst
@@ -1,0 +1,6 @@
+sklearn
+=======
+
+.. automodule:: openTSNE.sklearn
+    :members: TSNE
+    :undoc-members:

--- a/openTSNE/sklearn.py
+++ b/openTSNE/sklearn.py
@@ -1,0 +1,57 @@
+import openTSNE
+import numpy as np
+
+
+class TSNE(openTSNE.TSNE):
+    __doc__ = openTSNE.TSNE.__doc__
+
+    def fit(self, X, y=None):
+        """Fit X into an embedded space.
+
+        Parameters
+        ----------
+        X: np.ndarray
+            The data matrix to be embedded.
+        y : ignored
+
+        """
+        self.fit_transform(X, y)
+        return self
+
+    def fit_transform(self, X, y=None):
+        """Fit X into an embedded space and return that transformed output.
+
+        Parameters
+        ----------
+        X: np.ndarray
+            The data matrix to be embedded.
+        y : ignored
+
+        Returns
+        -------
+        np.ndarray
+            Embedding of the training data in low-dimensional space.
+
+        """
+        embedding = super().fit(X)
+        self.embedding_ = embedding
+        return self.embedding_.view(np.ndarray)
+
+    def transform(self, X, *args, **kwargs):
+        """Apply dimensionality reduction to X.
+
+        See :meth:`openTSNE.TSNEEmbedding.transform` for additional parameters.
+
+        Parameters
+        ----------
+        X: np.ndarray
+            The data matrix to be embedded.
+
+        Returns
+        -------
+        np.ndarray
+            Embedding of the training data in low-dimensional space.
+
+        """
+        embedding = self.embedding_.transform(X, *args, **kwargs)
+        return embedding.view(np.ndarray)

--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -900,15 +900,33 @@ class TSNE(BaseEstimator):
 
     """
 
-    def __init__(self, n_components=2, perplexity=30, learning_rate=200,
-                 early_exaggeration_iter=250, early_exaggeration=12,
-                 n_iter=750, exaggeration=None,
-                 theta=0.5, n_interpolation_points=3, min_num_intervals=10,
-                 ints_in_interval=1, initialization="pca", metric="euclidean",
-                 metric_params=None, initial_momentum=0.5, final_momentum=0.8,
-                 min_grad_norm=1e-8, max_grad_norm=None,
-                 n_jobs=1, neighbors="approx", negative_gradient_method="fft",
-                 callbacks=None, callbacks_every_iters=50, random_state=None):
+    def __init__(
+        self,
+        n_components=2,
+        perplexity=30,
+        learning_rate=200,
+        early_exaggeration_iter=250,
+        early_exaggeration=12,
+        n_iter=750,
+        exaggeration=None,
+        theta=0.5,
+        n_interpolation_points=3,
+        min_num_intervals=10,
+        ints_in_interval=1,
+        initialization="pca",
+        metric="euclidean",
+        metric_params=None,
+        initial_momentum=0.5,
+        final_momentum=0.8,
+        min_grad_norm=1e-8,
+        max_grad_norm=None,
+        n_jobs=1,
+        neighbors="approx",
+        negative_gradient_method="fft",
+        callbacks=None,
+        callbacks_every_iters=50,
+        random_state=None,
+    ):
         self.n_components = n_components
         self.perplexity = perplexity
         self.learning_rate = learning_rate

--- a/tests/test_sklearn_wrapper.py
+++ b/tests/test_sklearn_wrapper.py
@@ -1,0 +1,34 @@
+import unittest
+import numpy as np
+
+from openTSNE.sklearn import TSNE
+
+
+class TestTSNECorrectness(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tsne = TSNE(
+            early_exaggeration_iter=20,
+            n_iter=100,
+            neighbors="exact",
+            negative_gradient_method="bh",
+        )
+        # Set up two modalities, if we want to viually inspect test results
+        random_state = np.random.RandomState(0)
+        cls.x = np.vstack(
+            (random_state.normal(+1, 1, (100, 4)), random_state.normal(-1, 1, (100, 4)))
+        )
+        cls.x_test = random_state.normal(0, 1, (25, 4))
+
+    def test_fit(self):
+        retval = self.tsne.fit(self.x)
+        self.assertIs(type(retval), TSNE)
+
+    def test_fit_transform(self):
+        retval = self.tsne.fit_transform(self.x)
+        self.assertIs(type(retval), np.ndarray)
+
+    def test_transform(self):
+        self.tsne.fit(self.x)
+        retval = self.tsne.transform(self.x_test)
+        self.assertIs(type(retval), np.ndarray)


### PR DESCRIPTION
##### Issue
While the API is fairly similar to scikit-learn, it's still annoying to switch out different methods due to openTSNE returning the embedding from `fit` and scikit-learn returning the fitter object. This means that when I want to switch out MDS for t-SNE, I not only need to change the object but also the method from `fit_transform` to `fit`.


##### Description of changes
Implement scikit-learn API.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
