### PR TITLE
Ensure numpy is installed on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
     pip: true
 
 install:
+    - pip install numpy>=1.14
     - python setup.py develop
     - pip install flake8
 


### PR DESCRIPTION
##### Notes
The `setup_requires` directive in setuptools seemed promising as a way to bootstrap numpy before the compilation process. Unfortunately, this didn't work for some version mismatch reason ([stackoverflow question](https://stackoverflow.com/questions/56848016/setuptools-setup-requires-and-install-requires-behaves-differently))? So this idea was abandoned

##### Description of changes
Ensure numpy is installed on travis before setup takes place.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
