### PR TITLE
Add cosine distance support to ball tree

### DIFF
--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -84,7 +84,7 @@ class TestTSNECorrectness(unittest.TestCase):
     def test_iris_bh_transform_equivalency_with_one_by_one(self):
         """Compare one by one embedding vs all at once using BH gradients."""
         x_train, x_test = train_test_split(
-            self.iris.data, test_size=0.33, random_state=42
+            self.iris.data, test_size=0.1, random_state=42
         )
 
         # Set up the initial embedding
@@ -124,7 +124,7 @@ class TestTSNECorrectness(unittest.TestCase):
 
         """
         x_train, x_test = train_test_split(
-            self.iris.data, test_size=0.33, random_state=42
+            self.iris.data, test_size=0.1, random_state=42
         )
 
         # Set up the initial embedding


### PR DESCRIPTION
##### Issue
Exact nearest neighbor search provided by scikit-learn did not implement cosine distance, because I guess you can't really compute that using the tree-based methods and it would be computed using pdist.


##### Description of changes
We can exploit the fact that the distance rankings are the same for cosine distance as they are for euclidean distance on instance-normalized data. So we can find the nearest neighbors using the standard euclidean ball trees, then recompute the true cosine distance for only these neighbors.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
