### PR TITLE
Fix pickling for TSNEEmbedding objects; missing optimizer

### DIFF
--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -812,6 +812,29 @@ class TSNEEmbedding(np.ndarray):
             **self.gradient_descent_params,
         )
 
+    def __reduce__(self):
+        state = super().__reduce__()
+        new_state = state[2] + (
+            self.affinities,
+            self.gradient_descent_params,
+            self.random_state,
+            self.kl_divergence,
+        )
+        return state[0], state[1], new_state
+
+    def __setstate__(self, state):
+        self.kl_divergence = state[-1]
+        self.random_state = state[-2]
+        self.gradient_descent_params = state[-3]
+        self.affinities = state[-4]
+        super().__setstate__(state[0:-4])
+
+
+def _create_embedding(coords, affinities, random_state, optimizer, grad_params, kl_divergence):
+    embedding = TSNEEmbedding(coords, affinities, random_state, optimizer, **grad_params)
+    embedding.kl_divergence = kl_divergence
+    return embedding
+
 
 class TSNE(BaseEstimator):
     """t-Distributed Stochastic Neighbor Embedding.

--- a/tests/test_tsne.py
+++ b/tests/test_tsne.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import pickle
 import unittest
 from functools import wraps, partial
 from typing import Callable, Any, Tuple, Optional
@@ -728,6 +729,12 @@ class TestGradientDescentOptimizer(unittest.TestCase):
         self.assertIs(partial0.optimizer, partial1.optimizer)
         self.assertIs(partial1.optimizer, partial2.optimizer)
 
+    def test_pickling(self):
+        obj = openTSNE.tsne.gradient_descent()
+        obj.gains = np.ones(5)
+        loaded_obj = pickle.loads(pickle.dumps(obj))
+        np.testing.assert_array_equal(loaded_obj.gains, np.ones(5))
+
 
 class TestAffinityIntegration(unittest.TestCase):
     @classmethod
@@ -756,3 +763,13 @@ class TestAffinityIntegration(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             embedding.transform(self.x_test)
+
+
+class TestTSNEEmebedding(unittest.TestCase):
+    def test_pickling(self):
+        tsne = TSNE(random_state=4)
+        embedding = tsne.fit(np.random.randn(100, 4))
+        loaded_obj = pickle.loads(pickle.dumps(embedding))
+        self.assertIsInstance(loaded_obj, openTSNE.TSNEEmbedding)
+        self.assertIsInstance(loaded_obj.affinities, openTSNE.affinity.Affinities)
+        self.assertEqual(4, loaded_obj.random_state)


### PR DESCRIPTION
##### Issue
Pickling doesn't work for `TSNEEmbedding` objects. 


##### Description of changes
Fix picking. For some reason, things crash if I try to include the `optimizer` in the pickle, even though it's pickled fine on its own. So the optimizer is not included.

In general, this might not be a problem because the typical use case for pickling would be to create the embedding, then use if for subsequent transforms. It can even be optimized later on as well, but the momentum terms will be reset when unpickling.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
