### PR TITLE
Fix numpy version to 1.16.*

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     - PYTHON: "C:\\Python37-x64"
 
 install:
-  - "%PYTHON%\\python.exe -m pip install numpy"
+  - "%PYTHON%\\python.exe -m pip install numpy==1.16.4"
   - "%PYTHON%\\python.exe setup.py develop"
   - "%PYTHON%\\python.exe -m pip install pytest"
 

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ setup(
     packages=setuptools.find_packages(include=["openTSNE", "openTSNE.*"]),
     python_requires=">=3.6",
     install_requires=[
-        "numpy>1.14",
+        "numpy==1.16.*",
         "scikit-learn>=0.20",
         "scipy",
         "pynndescent>=0.3",


### PR DESCRIPTION
##### Issue
`pynndescent` is incompatible with the latest numpy release 1.17.0


##### Description of changes
Fix numpy version to 1.16.*


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
