### PR TITLE
Remove constant 4 factor from gradients

### DIFF
--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -1181,7 +1181,6 @@ def kl_divergence_bh(embedding, P, dof, bh_params, reference_embedding=None,
         dof, num_threads=n_jobs, should_eval_error=should_eval_error,
     )
 
-    gradient *= 2 * (dof + 1) / dof
     # Computing positive gradients summed up only unnormalized q_ijs, so we
     # have to include normalziation term separately
     if should_eval_error:
@@ -1230,7 +1229,6 @@ def kl_divergence_fft(embedding, P, dof, fft_params, reference_embedding=None,
         dof, num_threads=n_jobs, should_eval_error=should_eval_error,
     )
 
-    gradient *= 2 * (dof + 1) / dof
     if should_eval_error:
         kl_divergence_ += sum_P * np.log(sum_Q + EPSILON)
 


### PR DESCRIPTION
##### Issue
Fixes #80

##### Description of changes
Remove constant factor from gradients. This deviates from the true gradient and the implementation in scikit-learn, but is now consistent with FIt-SNE and van der Maaten's implementation.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
