### PR TITLE
Add support for callable metrics

### DIFF
--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -83,7 +83,7 @@ class PerplexityBasedNN(Affinities):
         Specifies the nearest neighbor method to use. Can be either ``exact`` or
         ``approx``.
 
-    metric: str
+    metric: Union[str, Callable]
         The metric to be used to compute affinities between points in the
         original space.
 
@@ -390,7 +390,7 @@ class FixedSigmaNN(Affinities):
         Specifies the nearest neighbor method to use. Can be either ``exact`` or
         ``approx``.
 
-    metric: str
+    metric: Union[str, Callable]
         The metric to be used to compute affinities between points in the
         original space.
 
@@ -557,7 +557,7 @@ class MultiscaleMixture(Affinities):
         Specifies the nearest neighbor method to use. Can be either ``exact`` or
         ``approx``.
 
-    metric: str
+    metric: Union[str, Callable]
         The metric to be used to compute affinities between points in the
         original space.
 
@@ -796,7 +796,7 @@ class Multiscale(MultiscaleMixture):
         Specifies the nearest neighbor method to use. Can be either ``exact`` or
         ``approx``.
 
-    metric: str
+    metric: Union[str, Callable]
         The metric to be used to compute affinities between points in the
         original space.
 

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -56,14 +56,14 @@ class KNNIndex:
     def check_metric(self, metric):
         """Check that the metric is supported by the KNNIndex instance."""
         if callable(metric):
-            pass
+            return metric
         elif metric not in self.VALID_METRICS:
             raise ValueError(
                 f"`{self.__class__.__name__}` does not support the `{metric}` "
                 f"metric. Please choose one of the supported metrics: "
                 f"{', '.join(self.VALID_METRICS)}."
             )
-        return metric
+            return metric
 
 
 class BallTree(KNNIndex):
@@ -175,7 +175,7 @@ class NNDescent(KNNIndex):
         "yule",
     ]
 
-    def check_metric(self, metric, *args, **kwargs):
+    def check_metric(self, *args, **kwargs):
         import pynndescent
 
         if not np.array_equal(pynndescent.distances.named_distances, self.VALID_METRICS):
@@ -185,24 +185,24 @@ class NNDescent(KNNIndex):
                 "developers of this change."
             )
 
-        if callable(metric):
-            from numba.targets.registry import CPUDispatcher
+        #if callable(metric):
+        #    from numba.targets.registry import CPUDispatcher
 
-            if type(metric) is not CPUDispatcher:
-                from numba import njit
+        #    if type(metric) is not CPUDispatcher:
+        #        from numba import njit
 
-                warnings.warn(
-                    "`pynndescent` requires callable metrics to be compiled with numba, "
-                    "but you have passed a callable metric that is not compiled. "
-                    "`openTSNE.nearest_neighbors.NNDescent` will attempt to compile the function. "
-                    "If this results in an error, then the function is not "
-                    "compatible with numba.njit and must be rewritten. "
-                    "If the function cannot be rewritten to be compatible with numba.njit, "
-                    "then you must set `neighbors`='exact' to use `scikit-learn`."
-                    )
-                metric = njit()(metric)
+        #        warnings.warn(
+        #            "`pynndescent` requires callable metrics to be compiled with numba, "
+        #            "but you have passed a callable metric that is not compiled. "
+        #            "`openTSNE.nearest_neighbors.NNDescent` will attempt to compile the function. "
+        #            "If this results in an error, then the function is not "
+        #            "compatible with numba.njit and must be rewritten. "
+        #            "If the function cannot be rewritten to be compatible with numba.njit, "
+        #            "then you must set `neighbors`='exact' to use `scikit-learn`."
+        #            )
+        #        metric = njit()(metric)
 
-        return super().check_metric(metric, *args, **kwargs)
+        return super().check_metric(*args, **kwargs)
 
     def build(self, data, k):
         # These values were taken from UMAP, which we assume to be sensible defaults

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -202,7 +202,7 @@ class NNDescent(KNNIndex):
                     f"for calculating nearest neighbors."
                     )
                 from numba import njit
-                metric = njit()(metric)
+                metric = njit(fastmath=True)(metric)
 
         return super().check_metric(metric)
 

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -55,7 +55,9 @@ class KNNIndex:
 
     def check_metric(self, metric):
         """Check that the metric is supported by the KNNIndex instance."""
-        if metric not in self.VALID_METRICS:
+        if callable(metric):
+            pass
+        elif metric not in self.VALID_METRICS:
             raise ValueError(
                 f"`{self.__class__.__name__}` does not support the `{metric}` "
                 f"metric. Please choose one of the supported metrics: "
@@ -182,6 +184,17 @@ class NNDescent(KNNIndex):
                 "and `openTSNE.nearest_neighbors` has not been updated. Please notify the "
                 "developers of this change."
             )
+
+        if callable(metric):
+            from numba.targets.registry import CPUDispatcher
+
+            if type(metric) is not CPUDispatcher:
+                raise TypeError(
+                    "You have passed a callable metric that is not numba-compiled. "
+                    "`pynndescent` requires callable metrics to be numba-compiled. "
+                    "You must either compile the function with numba.njit or "
+                    "set `neighbors`='exact' to use `scikit-learn`."
+                    )
 
         return super().check_metric(*args, **kwargs)
 

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -56,14 +56,15 @@ class KNNIndex:
     def check_metric(self, metric):
         """Check that the metric is supported by the KNNIndex instance."""
         if callable(metric):
-            return metric
+            pass
         elif metric not in self.VALID_METRICS:
             raise ValueError(
                 f"`{self.__class__.__name__}` does not support the `{metric}` "
                 f"metric. Please choose one of the supported metrics: "
                 f"{', '.join(self.VALID_METRICS)}."
             )
-            return metric
+
+        return metric
 
 
 class BallTree(KNNIndex):
@@ -175,7 +176,7 @@ class NNDescent(KNNIndex):
         "yule",
     ]
 
-    def check_metric(self, metric, *args, **kwargs):
+    def check_metric(self, metric):
         import pynndescent
 
         if not np.array_equal(pynndescent.distances.named_distances, self.VALID_METRICS):
@@ -188,7 +189,7 @@ class NNDescent(KNNIndex):
         if callable(metric):
             from numba.targets.registry import CPUDispatcher
 
-            if type(metric) is not CPUDispatcher:
+            if not isinstance(metric, CPUDispatcher):
 
                 warnings.warn(
                     f"`pynndescent` requires callable metrics to be "
@@ -203,7 +204,7 @@ class NNDescent(KNNIndex):
                 from numba import njit
                 metric = njit()(metric)
 
-        return super().check_metric(metric, *args, **kwargs)
+        return super().check_metric(metric)
 
     def build(self, data, k):
         # These values were taken from UMAP, which we assume to be sensible defaults

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -175,7 +175,7 @@ class NNDescent(KNNIndex):
         "yule",
     ]
 
-    def check_metric(self, *args, **kwargs):
+    def check_metric(self, metric, *args, **kwargs):
         import pynndescent
 
         if not np.array_equal(pynndescent.distances.named_distances, self.VALID_METRICS):
@@ -185,24 +185,25 @@ class NNDescent(KNNIndex):
                 "developers of this change."
             )
 
-        #if callable(metric):
-        #    from numba.targets.registry import CPUDispatcher
+        if callable(metric):
+            from numba.targets.registry import CPUDispatcher
 
-        #    if type(metric) is not CPUDispatcher:
-        #        from numba import njit
+            if type(metric) is not CPUDispatcher:
 
-        #        warnings.warn(
-        #            "`pynndescent` requires callable metrics to be compiled with numba, "
-        #            "but you have passed a callable metric that is not compiled. "
-        #            "`openTSNE.nearest_neighbors.NNDescent` will attempt to compile the function. "
-        #            "If this results in an error, then the function is not "
-        #            "compatible with numba.njit and must be rewritten. "
-        #            "If the function cannot be rewritten to be compatible with numba.njit, "
-        #            "then you must set `neighbors`='exact' to use `scikit-learn`."
-        #            )
-        #        metric = njit()(metric)
+                warnings.warn(
+                    f"`pynndescent` requires callable metrics to be "
+                    f"compiled with `numba`, but `{metric.__name__}` is not compiled. "
+                    f"`openTSNE.nearest_neighbors.NNDescent` "
+                    f"will attempt to compile the function. "
+                    f"If this results in an error, then the function may not be "
+                    f"compatible with `numba.njit` and should be rewritten. "
+                    f"Otherwise, set `neighbors`='exact' to use `scikit-learn` "
+                    f"for calculating nearest neighbors."
+                    )
+                from numba import njit
+                metric = njit()(metric)
 
-        return super().check_metric(*args, **kwargs)
+        return super().check_metric(metric, *args, **kwargs)
 
     def build(self, data, k):
         # These values were taken from UMAP, which we assume to be sensible defaults

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -190,7 +190,6 @@ class NNDescent(KNNIndex):
             from numba.targets.registry import CPUDispatcher
 
             if not isinstance(metric, CPUDispatcher):
-
                 warnings.warn(
                     f"`pynndescent` requires callable metrics to be "
                     f"compiled with `numba`, but `{metric.__name__}` is not compiled. "

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -189,12 +189,18 @@ class NNDescent(KNNIndex):
             from numba.targets.registry import CPUDispatcher
 
             if type(metric) is not CPUDispatcher:
-                raise TypeError(
-                    "You have passed a callable metric that is not numba-compiled. "
-                    "`pynndescent` requires callable metrics to be numba-compiled. "
-                    "You must either compile the function with numba.njit or "
-                    "set `neighbors`='exact' to use `scikit-learn`."
+                from numba import njit
+
+                warnings.warn(
+                    "`pynndescent` requires callable metrics to be compiled with numba, "
+                    "but you have passed a callable metric that is not compiled. "
+                    "`openTSNE.nearest_neighbors.NNDescent` will attempt to compile the function. "
+                    "If this results in an error, then the function is not "
+                    "compatible with numba.njit and must be rewritten. "
+                    "If the function cannot be rewritten to be compatible with numba.njit, "
+                    "then you must set `neighbors`='exact' to use `scikit-learn`."
                     )
+                metric = njit()(metric)
 
         return super().check_metric(metric, *args, **kwargs)
 

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -175,7 +175,7 @@ class NNDescent(KNNIndex):
         "yule",
     ]
 
-    def check_metric(self, *args, **kwargs):
+    def check_metric(self, metric, *args, **kwargs):
         import pynndescent
 
         if not np.array_equal(pynndescent.distances.named_distances, self.VALID_METRICS):
@@ -196,7 +196,7 @@ class NNDescent(KNNIndex):
                     "set `neighbors`='exact' to use `scikit-learn`."
                     )
 
-        return super().check_metric(*args, **kwargs)
+        return super().check_metric(metric, *args, **kwargs)
 
     def build(self, data, k):
         # These values were taken from UMAP, which we assume to be sensible defaults

--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -906,7 +906,7 @@ class TSNE(BaseEstimator):
         point positions have small variance (var(Y) < 0.0001), otherwise you may
         get poor embeddings.
 
-    metric: str
+    metric: Union[str, Callable]
         The metric to be used to compute affinities between points in the
         original space.
 

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -73,7 +73,7 @@ class KNNIndexTestMixin:
 
         knn_index = self.knn_index("manhattan")
         knn_index.build(self.x1, k=k)
-        true_indices, true_distances = knn_index.query(self.x2, k=k)
+        true_indices_, true_distances_ = knn_index.query(self.x2, k=k)
 
         def manhattan(x, y):
             return np.sum(np.abs(x - y))
@@ -93,7 +93,7 @@ class KNNIndexTestMixin:
 
         knn_index = self.knn_index("manhattan")
         knn_index.build(self.x1, k=k)
-        true_indices, true_distances = knn_index.query(self.x2, k=k)
+        true_indices_, true_distances_ = knn_index.query(self.x2, k=k)
 
         @njit()
         def manhattan(x, y):

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -69,6 +69,7 @@ class KNNIndexTestMixin:
         np.testing.assert_equal(distances1, distances2)
 
     def test_uncompiled_callable_metric_same_result(self):
+        k = 15
 
         knn_index = self.knn_index("manhattan")
         knn_index.build(self.x1, k=k)
@@ -88,6 +89,7 @@ class KNNIndexTestMixin:
         )
 
     def test_numba_compiled_callable_metric_same_result(self):
+        k = 15
 
         knn_index = self.knn_index("manhattan")
         knn_index.build(self.x1, k=k)

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -103,7 +103,7 @@ class KNNIndexTestMixin:
         knn_index.build(self.x1, k=k)
         true_indices_, true_distances_ = knn_index.query(self.x2, k=k)
 
-        @numba.njit(fastmath=True)
+        @njit(fastmath=True)
         def manhattan(x, y):
             r"""Manhattan, taxicab, or l1 distance.
             .. math::

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -76,7 +76,15 @@ class KNNIndexTestMixin:
         true_indices_, true_distances_ = knn_index.query(self.x2, k=k)
 
         def manhattan(x, y):
-            return np.sum(np.abs(x - y))
+            r"""Manhattan, taxicab, or l1 distance.
+            .. math::
+                D(x, y) = \sum_i |x_i - y_i|
+            """
+            result = 0.0
+            for i in range(x.shape[0]):
+                result += np.abs(x[i] - y[i])
+
+            return result
 
         knn_index = self.knn_index(manhattan, random_state=1)
         knn_index.build(self.x1, k=k)
@@ -95,9 +103,17 @@ class KNNIndexTestMixin:
         knn_index.build(self.x1, k=k)
         true_indices_, true_distances_ = knn_index.query(self.x2, k=k)
 
-        @njit()
+        @numba.njit(fastmath=True)
         def manhattan(x, y):
-            return np.sum(np.abs(x - y))
+            r"""Manhattan, taxicab, or l1 distance.
+            .. math::
+                D(x, y) = \sum_i |x_i - y_i|
+            """
+            result = 0.0
+            for i in range(x.shape[0]):
+                result += np.abs(x[i] - y[i])
+
+            return result
 
         knn_index = self.knn_index(manhattan, random_state=1)
         knn_index.build(self.x1, k=k)
@@ -169,7 +185,15 @@ class TestNNDescent(KNNIndexTestMixin, unittest.TestCase):
         knn_index = nearest_neighbors.NNDescent("manhattan")
 
         def manhattan(x, y):
-            return np.sum(np.abs(x - y))
+            r"""Manhattan, taxicab, or l1 distance.
+            .. math::
+                D(x, y) = \sum_i |x_i - y_i|
+            """
+            result = 0.0
+            for i in range(x.shape[0]):
+                result += np.abs(x[i] - y[i])
+
+            return result
 
         compiled_metric = knn_index.check_metric(manhattan)
         self.assertTrue(isinstance(compiled_metric, CPUDispatcher))

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -14,7 +14,7 @@ from .test_tsne import check_mock_called_with_kwargs
 
 
 class KNNIndexTestMixin:
-    knn_index = None
+    knn_index = NotImplemented
 
     def __init__(self, *args, **kwargs):
         self.x1 = np.random.normal(100, 50, (150, 50))

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -76,10 +76,6 @@ class KNNIndexTestMixin:
         true_indices_, true_distances_ = knn_index.query(self.x2, k=k)
 
         def manhattan(x, y):
-            r"""Manhattan, taxicab, or l1 distance.
-            .. math::
-                D(x, y) = \sum_i |x_i - y_i|
-            """
             result = 0.0
             for i in range(x.shape[0]):
                 result += np.abs(x[i] - y[i])
@@ -105,10 +101,6 @@ class KNNIndexTestMixin:
 
         @njit(fastmath=True)
         def manhattan(x, y):
-            r"""Manhattan, taxicab, or l1 distance.
-            .. math::
-                D(x, y) = \sum_i |x_i - y_i|
-            """
             result = 0.0
             for i in range(x.shape[0]):
                 result += np.abs(x[i] - y[i])
@@ -181,14 +173,9 @@ class TestNNDescent(KNNIndexTestMixin, unittest.TestCase):
         check_mock_called_with_kwargs(nndescent, {"random_state": random_state})
 
     def test_uncompiled_callable_is_compiled(self):
-
         knn_index = nearest_neighbors.NNDescent("manhattan")
 
         def manhattan(x, y):
-            r"""Manhattan, taxicab, or l1 distance.
-            .. math::
-                D(x, y) = \sum_i |x_i - y_i|
-            """
             result = 0.0
             for i in range(x.shape[0]):
                 result += np.abs(x[i] - y[i])

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -71,14 +71,14 @@ class KNNIndexTestMixin:
     def test_uncompiled_callable_metric_same_result(self):
         k = 15
 
-        knn_index = self.knn_index("manhattan")
+        knn_index = self.knn_index("manhattan", random_state=1)
         knn_index.build(self.x1, k=k)
         true_indices_, true_distances_ = knn_index.query(self.x2, k=k)
 
         def manhattan(x, y):
             return np.sum(np.abs(x - y))
 
-        knn_index = self.knn_index(manhattan)
+        knn_index = self.knn_index(manhattan, random_state=1)
         knn_index.build(self.x1, k=k)
         indices, distances = knn_index.query(self.x2, k=k)
         np.testing.assert_array_equal(
@@ -91,7 +91,7 @@ class KNNIndexTestMixin:
     def test_numba_compiled_callable_metric_same_result(self):
         k = 15
 
-        knn_index = self.knn_index("manhattan")
+        knn_index = self.knn_index("manhattan", random_state=1)
         knn_index.build(self.x1, k=k)
         true_indices_, true_distances_ = knn_index.query(self.x2, k=k)
 
@@ -99,7 +99,7 @@ class KNNIndexTestMixin:
         def manhattan(x, y):
             return np.sum(np.abs(x - y))
 
-        knn_index = self.knn_index(manhattan)
+        knn_index = self.knn_index(manhattan, random_state=1)
         knn_index.build(self.x1, k=k)
         indices, distances = knn_index.query(self.x2, k=k)
         np.testing.assert_array_equal(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
See #93  

##### Description of changes
Added the option for callable metrics to the `openTSNE.nearest_neighbors` module. `NNDescent` checks if metric is compiled with `numba`, gives an informative warning, and then attempts to automatically compile it. If the function is already compiled or `NNDescent` is not being used then the callable is passed without any further checks. Docstrings have also been updated to match other docstrings with multiple types. If you'd like unit tests for this, then please provide guidance on how best to do this. 

##### Includes
- [X] Code changes
- [ ] Tests
- [X] Documentation
