### PR TITLE
Add spectral initialization using diffusion maps

### DIFF
--- a/openTSNE/initialization.py
+++ b/openTSNE/initialization.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy.sparse as sp
 from sklearn.decomposition import PCA
 from sklearn.utils import check_random_state
 
@@ -66,6 +67,63 @@ def pca(X, n_components=2, svd_solver="auto", random_state=None):
     embedding /= normalization
 
     return np.ascontiguousarray(embedding)
+
+
+def spectral(A, n_components=2, tol=1e-4, max_iter=None):
+    """Initialize an embedding using the spectral embedding of the KNN graph.
+
+    Specifically, we initialize data points by computing the diffusion map on
+    the random walk transition matrix of the weighted graph given by the affiniy
+    matrix.
+
+    Parameters
+    ----------
+    A: Union[sp.csr_matrix, sp.csc_matrix, ...]
+        The graph adjacency matrix.
+
+    n_components: int
+        The dimension of the embedding space.
+
+    tol: float
+        See scipy.sparse.linalg.eigsh documentation.
+
+    max_iter: float
+        See scipy.sparse.linalg.eigsh documentation.
+
+    Returns
+    -------
+    initialization: np.ndarray
+
+    """
+    if A.ndim != 2:
+        raise ValueError("The graph adjacency matrix must be a 2-dimensional matrix.")
+    if A.shape[0] != A.shape[1]:
+        raise ValueError("The graph adjacency matrix must be a square matrix.")
+
+    D = sp.diags(np.ravel(np.sum(A, axis=1)))
+
+    # Find leading eigenvectors
+    k = n_components + 1
+    v0 = np.ones(A.shape[0]) / np.sqrt(A.shape[0])
+    eigvals, eigvecs = sp.linalg.eigsh(
+        A, M=D, k=k, tol=tol, maxiter=max_iter, which="LM", v0=v0
+    )
+    # Sort the eigenvalues in decreasing order
+    order = np.argsort(eigvals)[::-1]
+    eigvecs = eigvecs[:, order]
+
+    # In diffusion maps, we multiply the eigenvectors by their eigenvalues
+    eigvecs *= eigvals
+
+    # Drop the leading eigenvector
+    embedding = eigvecs[:, 1:]
+
+    # Ensure low variance
+    normalization = np.std(embedding[:, 0])
+    normalization /= 0.0001
+    embedding /= normalization
+
+    return embedding
 
 
 def weighted_mean(X, embedding, neighbors, distances):


### PR DESCRIPTION
##### Description of changes
Fixes #110.

I ended up implementing diffusion maps only because computationally, computing the leading eigenvectors is much faster than the smallest eigenvectors, and of the various spectral methods, diffusion maps are the only ones that require this. I checked what UMAP does - it uses the symmetric normalized laplacian for initialization - but they manually set the number of lanczos iteration limit, which I don't understand. This seemed like the better option.

@dkobak Do you want to take a look at this? I implemented this using `scipy.sparse.linalg.svds` because it turns out to be faster than `scipy.sparse.linalg.eigsh` and it seemed to produce strange results when I increased the error tolerance, while `svds` results seemed reasonable.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
