### PR TITLE
[FIX] Removed warnings filters, DeprecationWarnings replaced with FutureWarning

### DIFF
--- a/openTSNE/callbacks.py
+++ b/openTSNE/callbacks.py
@@ -11,9 +11,6 @@ from openTSNE.tsne import TSNEEmbedding
 
 log = logging.getLogger(__name__)
 
-# Enable warnings for this module
-warnings.simplefilter("module")
-
 
 class Callback:
     def optimization_about_to_start(self):
@@ -55,7 +52,7 @@ class ErrorLogger(Callback):
         warnings.warn(
             "`ErrorLogger` will be removed in upcoming version. Please use the "
             "`verbose` flag instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
         )
         self.iter_count = 0
         self.last_log_time = None

--- a/openTSNE/utils.py
+++ b/openTSNE/utils.py
@@ -2,9 +2,6 @@ from functools import wraps
 from time import time
 import warnings
 
-# Enable warnings for this module
-warnings.simplefilter("module")
-
 
 class Timer:
     def __init__(self, message, verbose=False):
@@ -30,7 +27,7 @@ def deprecate_parameter(parameter):
                 warnings.warn(
                     f"The parameter `{parameter}` has been deprecated and will be "
                     f"removed in future versions",
-                    category=DeprecationWarning,
+                    category=FutureWarning,
                 )
             return f(*args, **kwargs)
         return func


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
- Warning filters override filters from other packages (e.g. filter for OrangeDeprecationWarning was overridden - test started to fail)
- DeprecationWarning can be replaced with FutureWarning:
   ```
   Base category for warnings about deprecated features when those warnings are intended for 
   end-users of applications that are written in Python.
   ```
   As far I understand DeprecationWarning is made for developers of the package (in your case openTSNE developers), while FutreWarning is for users of your package. FutreWarning is printed by default.

##### Description of changes
- Removed filters
- DeprecationWarning replaced with FutureWarning

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
