### PR TITLE
max update norm parameter

### DIFF
--- a/tests/test_tsne.py
+++ b/tests/test_tsne.py
@@ -90,6 +90,7 @@ class TestTSNEParameterFlow(unittest.TestCase):
         "min_num_intervals": [10, 20, 30],
         "ints_in_interval": [1, 2, 5],
         "max_grad_norm": [None, 0.5, 1],
+        "max_step_norm": [None, 1, 5],
         "n_jobs": [1, 2, 4],
         "callbacks": [None, [lambda *args, **kwargs: ...]],
         "callbacks_every_iters": [25, 50],
@@ -161,6 +162,7 @@ class TestTSNEParameterFlow(unittest.TestCase):
         "initial_momentum": [0.2, 0.5, 0.8],
         "final_momentum": [0.2, 0.5, 0.8],
         "max_grad_norm": [None, 0.5, 1],
+        "max_step_norm": [None, 1, 5],
     })
     @patch("openTSNE.tsne.gradient_descent.__call__")
     def test_embedding_transform(self, param_name, param_value, gradient_descent):
@@ -191,6 +193,7 @@ class TestTSNEParameterFlow(unittest.TestCase):
         "exaggeration": [None, 2, 5],
         "momentum": [0.2, 0.5, 0.8],
         "max_grad_norm": [None, 0.5, 1],
+        "max_step_norm": [None, 1, 5],
     }})
     @patch("openTSNE.tsne.gradient_descent.__call__")
     def test_partial_embedding_optimize(self, param_name, param_value, gradient_descent):


### PR DESCRIPTION
Fixes #132.

I tested it on MNIST with default parameters and the default `max_step_norm=5` (same as in FIt-SNE) does not affect the embedding (I think it's never triggered). If one sets it to a much smaller number, it produces a funny effect:

![tmp-opentsne-step001](https://user-images.githubusercontent.com/8970231/81945522-82635080-95fe-11ea-9f89-4b241b163c9a.png)

Here with `max_step_norm=0.01` no point can be further than 7.5 from zero (with 750 iterations).

@jnboehm tested it on one case where we had some points shooting off (with strong exaggeration factor), and the default `max_step_norm=5` resolved the problem.

For `transform()` I set the default to `None` because there you have nonzero `max_grad_norm` by default so I thought it might be enough. You are also limiting the interpolation grid there, I think.