### PR TITLE
Pynndescent fixes

### DIFF
--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -369,11 +369,25 @@ class NNDescent(KNNIndex):
         # unless we're actually going to use it
         import pynndescent
 
+        # Will use query() only for k>15
+        if k <= 15:
+            n_neighbors_build = k + 1
+        else:
+            n_neighbors_build = 15
+
+        # due to a bug, pynndescent currently does not support n_jobs>1
+        # for sparse inputs. This should be removed once it's fixed.
+        n_jobs_pynndescent = self.n_jobs
+        import scipy.sparse as sp
+
+        if sp.issparse(data):
+            n_jobs_pynndescent = 1
+
         # UMAP uses the "alternative" algorithm, but that sometimes causes
         # memory corruption, so use the standard one, which seems to work fine
         self.index = pynndescent.NNDescent(
             data,
-            n_neighbors=15,
+            n_neighbors=n_neighbors_build,
             metric=self.metric,
             metric_kwds=self.metric_params,
             random_state=self.random_state,
@@ -381,10 +395,29 @@ class NNDescent(KNNIndex):
             n_iters=n_iters,
             algorithm="standard",
             max_candidates=60,
-            n_jobs=self.n_jobs,
+            n_jobs=n_jobs_pynndescent,
         )
 
-        indices, distances = self.index.query(data, k=k + 1)
+        # -1 in indices means that pynndescent failed
+        indices, distances = self.index.neighbor_graph
+        mask = np.sum(indices == -1, axis=1) > 0
+
+        if k > 15:
+            indices, distances = self.index.query(data, k=k + 1)
+
+        # as a workaround, we let the failed points group together
+        if np.sum(mask) > 0:
+            warnings.warn(
+                f"`pynndescent` failed to find neighbors for some of the points."
+                f"As a workaround, openTSNE considers all such points similar to "
+                f"each other, so they will likely form a cluster in the embedding."
+            )
+            distances[mask] = 1
+            fake_indices = np.random.choice(
+                np.sum(mask), size=np.sum(mask) * indices.shape[1]
+            )
+            fake_indices = np.where(mask)[0][fake_indices]
+            indices[mask] = np.reshape(fake_indices, (np.sum(mask), indices.shape[1]))
 
         timer.__exit__()
 
@@ -403,3 +436,4 @@ class NNDescent(KNNIndex):
         timer.__exit__()
 
         return indices, distances
+


### PR DESCRIPTION
Fixes #130.

Changes:
1. Query() is only used for k>15.
2. n_jobs fixed to 1 for sparse inputs to avoid a pynndescent bug
3. find all points where index contains -1 values, and let them randomly attract each other.