### PR TITLE
Workaround for -1 in pynndescent index

### DIFF
--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -335,7 +335,7 @@ class NNDescent(KNNIndex):
             )
 
         if callable(metric):
-            from numba.targets.registry import CPUDispatcher
+            from numba.core.registry import CPUDispatcher
 
             if not isinstance(metric, CPUDispatcher):
                 warnings.warn(

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 from scipy.spatial.distance import cdist
 from sklearn import neighbors
+from sklearn.utils import check_random_state
 
 from openTSNE import utils
 
@@ -430,7 +431,8 @@ class NNDescent(KNNIndex):
                     f"Run with verbose=True, to see indices of the failed points."
                 )
             distances[mask] = 1
-            fake_indices = np.random.choice(
+            rs = check_random_state(self.random_state)
+            fake_indices = rs.choice(
                 np.sum(mask), size=np.sum(mask) * indices.shape[1], replace=True
             )
             fake_indices = np.where(mask)[0][fake_indices]

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -369,11 +369,25 @@ class NNDescent(KNNIndex):
         # unless we're actually going to use it
         import pynndescent
 
+        # Will use query() only for k>15
+        if k <= 15:
+            n_neighbors_build = k + 1
+        else:
+            n_neighbors_build = 15
+
+        # due to a bug, pynndescent currently does not support n_jobs>1
+        # for sparse inputs. This should be removed once it's fixed.
+        n_jobs_pynndescent = self.n_jobs
+        import scipy.sparse as sp
+
+        if sp.issparse(data):
+            n_jobs_pynndescent = 1
+
         # UMAP uses the "alternative" algorithm, but that sometimes causes
         # memory corruption, so use the standard one, which seems to work fine
         self.index = pynndescent.NNDescent(
             data,
-            n_neighbors=15,
+            n_neighbors=n_neighbors_build,
             metric=self.metric,
             metric_kwds=self.metric_params,
             random_state=self.random_state,
@@ -381,10 +395,29 @@ class NNDescent(KNNIndex):
             n_iters=n_iters,
             algorithm="standard",
             max_candidates=60,
-            n_jobs=self.n_jobs,
+            n_jobs=n_jobs_pynndescent,
         )
 
-        indices, distances = self.index.query(data, k=k + 1)
+        # -1 in indices means that pynndescent failed
+        indices, distances = self.index.neighbor_graph
+        mask = np.sum(indices == -1, axis=1) > 0
+
+        if k > 15:
+            indices, distances = self.index.query(data, k=k + 1)
+
+        # as a workaround, we let the failed points group together
+        if np.sum(mask) > 0:
+            warnings.warn(
+                f"`pynndescent` failed to find neighbors for some of the points."
+                f"As a workaround, openTSNE considers all such points similar to "
+                f"each other, so they will likely form a cluster in the embedding."
+            )
+            distances[mask] = 1
+            fake_indices = np.random.choice(
+                np.sum(mask), size=np.sum(mask) * indices.shape[1]
+            )
+            fake_indices = np.where(mask)[0][fake_indices]
+            indices[mask] = np.reshape(fake_indices, (np.sum(mask), indices.shape[1]))
 
         timer.__exit__()
 
@@ -403,3 +436,4 @@ class NNDescent(KNNIndex):
         timer.__exit__()
 
         return indices, distances
+

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -380,7 +380,7 @@ class NNDescent(KNNIndex):
         n_jobs_pynndescent = self.n_jobs
         import scipy.sparse as sp
 
-        if sp.issparse(data) and self.n_jobs > 1:
+        if sp.issparse(data) and self.n_jobs != 1:
             warnings.warn(
                 f"Running `pynndescent` with n_jobs=1 because it does not "
                 f"currently support n_jobs>1 with sparse inputs. See "

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -8,7 +8,7 @@ import pynndescent
 from sklearn import datasets
 
 from numba import njit
-from numba.targets.registry import CPUDispatcher
+from numba.core.registry import CPUDispatcher
 from sklearn.utils import check_random_state
 
 from openTSNE import nearest_neighbors


### PR DESCRIPTION
Fixes #130 .

Changes:

*    Query() is only used for k>15.
*    n_jobs fixed to 1 for sparse inputs to avoid a pynndescent bug
*    find all points where index contains -1 values, and let them randomly attract each other.
