### PR TITLE
Add hnswlib as k nearest neighbour index

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -70,7 +70,9 @@ jobs:
       - bash: python -m pip install -vv --force-reinstall --find-links dist openTSNE
         displayName: 'Install wheel'
 
-      - script: python -m pip install pynndescent
+      - script: |
+          python -m pip install pynndescent
+          python -m pip install hnswlib
         displayName: 'Install optional dependencies'
 
       - script: pytest -v
@@ -129,7 +131,9 @@ jobs:
       - bash: mv openTSNE src
         displayName: 'Remove source files from path'
 
-      - script: $(python)/pip install pynndescent
+      - script: |
+          $(python)/pip install pynndescent
+          $(python)/pip install hnswlib
         displayName: 'Install optional dependencies'
 
       - script: $(python)/python -m pytest -v
@@ -193,7 +197,9 @@ jobs:
       - bash: python -m pip install --force-reinstall --find-links dist openTSNE
         displayName: 'Install package'
 
-      - script: python -m pip install pynndescent
+      - script: |
+          python -m pip install pynndescent
+          python -m pip install hnswlib
         displayName: 'Install optional dependencies'
 
       - script: pytest -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,9 @@ jobs:
   - script: pip install -vv .
     displayName: 'Install package'
 
-  - script: pip install pynndescent
+  - script: |
+      pip install pynndescent
+      pip install hnswlib
     displayName: 'Install optional dependencies'
 
   # Since Python automatically adds `cwd` to `sys.path`, it's important we remove the local folder

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -86,7 +86,7 @@ class PerplexityBasedNN(Affinities):
 
     method: str
         Specifies the nearest neighbor method to use. Can be ``exact``, ``annoy``,
-        ``pynndescent``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
+        ``pynndescent``, ``hnsw``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
         if the input data matrix is not a sparse object and if Annoy supports
         the given metric. Otherwise it uses Pynndescent. ``auto`` uses exact
         nearest neighbors for N<1000 and the same heuristic as ``approx`` for N>=1000.
@@ -298,7 +298,7 @@ def build_knn_index(
         "approx": preferred_approx_method,
         "annoy": nearest_neighbors.Annoy,
         "pynndescent": nearest_neighbors.NNDescent,
-        "hnswlib": nearest_neighbors.HNSW
+        "hnsw": nearest_neighbors.HNSW
     }
     if isinstance(method, nearest_neighbors.KNNIndex):
         knn_index = method
@@ -616,7 +616,7 @@ class MultiscaleMixture(Affinities):
 
     method: str
         Specifies the nearest neighbor method to use. Can be ``exact``, ``annoy``,
-        ``pynndescent``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
+        ``pynndescent``, ``hnsw``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
         if the input data matrix is not a sparse object and if Annoy supports
         the given metric. Otherwise it uses Pynndescent. ``auto`` uses exact
         nearest neighbors for N<1000 and the same heuristic as ``approx`` for N>=1000.
@@ -871,7 +871,7 @@ class Multiscale(MultiscaleMixture):
 
     method: str
         Specifies the nearest neighbor method to use. Can be ``exact``, ``annoy``,
-        ``pynndescent``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
+        ``pynndescent``, ``hnsw``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
         if the input data matrix is not a sparse object and if Annoy supports
         the given metric. Otherwise it uses Pynndescent. ``auto`` uses exact
         nearest neighbors for N<1000 and the same heuristic as ``approx`` for N>=1000.
@@ -951,7 +951,7 @@ class Uniform(Affinities):
 
     method: str
         Specifies the nearest neighbor method to use. Can be ``exact``, ``annoy``,
-        ``pynndescent``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
+        ``pynndescent``, ``hnsw``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
         if the input data matrix is not a sparse object and if Annoy supports
         the given metric. Otherwise it uses Pynndescent. ``auto`` uses exact
         nearest neighbors for N<1000 and the same heuristic as ``approx`` for N>=1000.

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -298,6 +298,7 @@ def build_knn_index(
         "approx": preferred_approx_method,
         "annoy": nearest_neighbors.Annoy,
         "pynndescent": nearest_neighbors.NNDescent,
+        "hnswlib": nearest_neighbors.HNSW
     }
     if isinstance(method, nearest_neighbors.KNNIndex):
         knn_index = method

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -12,7 +12,7 @@ class KNNIndex:
     VALID_METRICS = []
 
     def __init__(
-            self, metric, metric_params=None, n_jobs=1, random_state=None, verbose=False
+        self, metric, metric_params=None, n_jobs=1, random_state=None, verbose=False
     ):
         self.index = None
         self.metric = self.check_metric(metric)
@@ -94,7 +94,7 @@ class BallTree(KNNIndex):
             effective_metric = "euclidean"
             effective_data = data.copy()
             effective_data = (
-                    effective_data / np.linalg.norm(effective_data, axis=1)[:, None]
+                effective_data / np.linalg.norm(effective_data, axis=1)[:, None]
             )
             # In order to properly compute cosine distances when querying the
             # index, we need to store the original data
@@ -140,7 +140,7 @@ class BallTree(KNNIndex):
         if self.metric == "cosine":
             effective_data = query.copy()
             effective_data = (
-                    effective_data / np.linalg.norm(effective_data, axis=1)[:, None]
+                effective_data / np.linalg.norm(effective_data, axis=1)[:, None]
             )
         else:
             effective_data = query
@@ -330,7 +330,7 @@ class NNDescent(KNNIndex):
         import pynndescent
 
         if not np.array_equal(
-                list(pynndescent.distances.named_distances), self.VALID_METRICS
+            list(pynndescent.distances.named_distances), self.VALID_METRICS
         ):
             warnings.warn(
                 "`pynndescent` has recently changed which distance metrics are supported, "

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -12,7 +12,7 @@ class KNNIndex:
     VALID_METRICS = []
 
     def __init__(
-        self, metric, metric_params=None, n_jobs=1, random_state=None, verbose=False
+            self, metric, metric_params=None, n_jobs=1, random_state=None, verbose=False
     ):
         self.index = None
         self.metric = self.check_metric(metric)
@@ -94,7 +94,7 @@ class BallTree(KNNIndex):
             effective_metric = "euclidean"
             effective_data = data.copy()
             effective_data = (
-                effective_data / np.linalg.norm(effective_data, axis=1)[:, None]
+                    effective_data / np.linalg.norm(effective_data, axis=1)[:, None]
             )
             # In order to properly compute cosine distances when querying the
             # index, we need to store the original data
@@ -140,7 +140,7 @@ class BallTree(KNNIndex):
         if self.metric == "cosine":
             effective_data = query.copy()
             effective_data = (
-                effective_data / np.linalg.norm(effective_data, axis=1)[:, None]
+                    effective_data / np.linalg.norm(effective_data, axis=1)[:, None]
             )
         else:
             effective_data = query
@@ -330,7 +330,7 @@ class NNDescent(KNNIndex):
         import pynndescent
 
         if not np.array_equal(
-            list(pynndescent.distances.named_distances), self.VALID_METRICS
+                list(pynndescent.distances.named_distances), self.VALID_METRICS
         ):
             warnings.warn(
                 "`pynndescent` has recently changed which distance metrics are supported, "
@@ -517,7 +517,7 @@ class HNSW(KNNIndex):
         timer.__enter__()
 
         # Set ef parameter for (ideal) precision/recall
-        self.index.set_ef(2 * k)
+        self.index.set_ef(min(2 * k, self.index.get_current_count()))
 
         # Query for kNN
         indices, distances = self.index.knn_query(query, k=k, num_threads=self.n_jobs)

--- a/setup.py
+++ b/setup.py
@@ -307,6 +307,7 @@ setup(
         "numpy>=1.14.6",
         "scikit-learn>=0.20",
         "scipy",
+        "hnswlib~=0.4.0"
     ],
 
     ext_modules=extensions,

--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,7 @@ extensions = [
     Extension("openTSNE.quad_tree", ["openTSNE/quad_tree.pyx"], language="c++"),
     Extension("openTSNE._tsne", ["openTSNE/_tsne.pyx"], language="c++"),
     Extension("openTSNE.kl_divergence", ["openTSNE/kl_divergence.pyx"], language="c++"),
-    annoy
+    annoy,
 ]
 
 
@@ -306,11 +306,11 @@ setup(
     install_requires=[
         "numpy>=1.14.6",
         "scikit-learn>=0.20",
-        "scipy"
+        "scipy",
     ],
     extras_require={
         "hnsw": "hnswlib~=0.4.0",
-        "pynndescent": "pynndescent~=0.5.0"
+        "pynndescent": "pynndescent~=0.5.0",
     },
     ext_modules=extensions,
     cmdclass={"build_ext": CythonBuildExt, "convert_notebooks": ConvertNotebooksToDocs},

--- a/setup.py
+++ b/setup.py
@@ -306,10 +306,12 @@ setup(
     install_requires=[
         "numpy>=1.14.6",
         "scikit-learn>=0.20",
-        "scipy",
-        "hnswlib~=0.4.0"
+        "scipy"
     ],
-
+    extras_require={
+        "hnsw": "hnswlib~=0.4.0",
+        "pynndescent": "pynndescent~=0.5.0"
+    },
     ext_modules=extensions,
     cmdclass={"build_ext": CythonBuildExt, "convert_notebooks": ConvertNotebooksToDocs},
 )

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -5,6 +5,7 @@ import numpy as np
 import scipy.sparse as sp
 from scipy.spatial.distance import pdist, cdist, squareform
 import pynndescent
+import hnswlib
 from sklearn import datasets
 
 from numba import njit
@@ -73,6 +74,10 @@ class KNNIndexTestMixin:
 
 class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
     knn_index = nearest_neighbors.Annoy
+
+
+class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
+    knn_index = nearest_neighbors.HNSW
 
 
 class TestBallTree(KNNIndexTestMixin, unittest.TestCase):


### PR DESCRIPTION
##### Issue
The kNN algorithms available in openTSNE are not as fast and/or memory efficient as HNSW (https://arxiv.org/abs/1603.09320).
Furthermore, Annoy, BallTree, and pynndescent are not made for high-dimensional data; For example, Annoy even throws an error above 1000 dimensions.

##### Description of changes
This pull request ...
* adds hnswlib as a dependency
* adds option to choose 'hnswlib' to `build_knn_index` for `Affinities`
* implements additional `KNNIndex` class to interface with hnswlib

##### Includes
- [X] Code changes
- [x] Tests
- [x] Documentation

If you like the idea of having HNSW as an alternative, I'll add tests and some documentation. 
