### PR TITLE
Allow to set k_neighors in perplexity based affinity

### DIFF
--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -265,7 +265,7 @@ class PerplexityBasedNN(Affinities):
         perplexity = perplexity if perplexity is not None else self.perplexity
         perplexity = self.check_perplexity(perplexity, self.n_samples)
          
-        k_neighbors = min(self.n_samples, int(3 * new_perplexity))
+        k_neighbors = min(self.n_samples, int(3 * perplexity))
 
         neighbors, distances = self.knn_index.query(data, k_neighbors)
 

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -277,7 +277,7 @@ class PerplexityBasedNN(Affinities):
         perplexity = perplexity if perplexity is not None else self.perplexity
         perplexity = self.check_perplexity(perplexity, _k_neighbors)
 
-        neighbors, distances = self.knn_index.query(data, k_neighbors)
+        neighbors, distances = self.knn_index.query(data, _k_neighbors)
 
         with utils.Timer("Calculating affinity matrix...", self.verbose):
             P = joint_probabilities_nn(

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -269,12 +269,13 @@ class PerplexityBasedNN(Affinities):
 
         """
         
+        perplexity = perplexity if perplexity is not None else self.perplexity
+
         if k_neighbors=="auto":
             _k_neighbors = min(self.n_samples, int(3 * perplexity))
         else:
             _k_neighbors = k_neighbors
 
-        perplexity = perplexity if perplexity is not None else self.perplexity
         perplexity = self.check_perplexity(perplexity, _k_neighbors)
 
         neighbors, distances = self.knn_index.query(data, _k_neighbors)

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -222,7 +222,9 @@ class PerplexityBasedNN(Affinities):
                 n_jobs=self.n_jobs,
             )
 
-    def to_new(self, data, perplexity=None, return_distances=False):
+    def to_new(
+        self, data, perplexity=None, return_distances=False, k_neighbors="auto"
+    ):
         """Compute the affinities of new samples to the initial samples.
 
         This is necessary for embedding new data points into an existing
@@ -244,6 +246,10 @@ class PerplexityBasedNN(Affinities):
             If needed, the function can return the indices of the nearest
             neighbors and their corresponding distances.
 
+        k_neighbors: int or ``auto``
+            The number of neighbors to query kNN graph for. If ``auto``
+            (default), it is set to three times the perplexity.
+
         Returns
         -------
         P: array_like
@@ -262,10 +268,14 @@ class PerplexityBasedNN(Affinities):
             data point.
 
         """
+        
+        if k_neighbors=="auto":
+            _k_neighbors = min(self.n_samples, int(3 * perplexity))
+        else:
+            _k_neighbors = k_neighbors
+
         perplexity = perplexity if perplexity is not None else self.perplexity
-        perplexity = self.check_perplexity(perplexity, self.n_samples)
-         
-        k_neighbors = min(self.n_samples, int(3 * perplexity))
+        perplexity = self.check_perplexity(perplexity, _k_neighbors)
 
         neighbors, distances = self.knn_index.query(data, k_neighbors)
 

--- a/tests/test_affinities.py
+++ b/tests/test_affinities.py
@@ -51,6 +51,11 @@ class TestPerplexityBased(unittest.TestCase):
         self.assertTrue(reduced_P.nnz < original_P.nnz,
                         "Lower perplexities should consider less neighbors, "
                         "resulting in a sparser affinity matrix")
+                        
+        # Check that increasing the perplexity works (with a warning)
+        perplexity = 40
+        aff.set_perplexity(perplexity)
+        self.assertEqual(aff.perplexity, perplexity)
 
         # Raising the perplexity above the number of neighbors in the kNN graph
         # would need to recompute the nearest neighbors, so it should raise an error

--- a/tests/test_affinities.py
+++ b/tests/test_affinities.py
@@ -23,7 +23,7 @@ class TestPerplexityBased(unittest.TestCase):
         cls.x = np.random.normal(100, 50, (91, 4))
 
     def test_properly_reduces_large_perplexity(self):
-        aff = PerplexityBasedNN(self.x, perplexity=40)
+        aff = PerplexityBasedNN(self.x, perplexity=140)
         self.assertEqual(aff.perplexity, 30)
 
     def test_handles_reducing_perplexity_value(self):
@@ -52,10 +52,10 @@ class TestPerplexityBased(unittest.TestCase):
                         "Lower perplexities should consider less neighbors, "
                         "resulting in a sparser affinity matrix")
 
-        # Raising the perplexity above the initial value would need to recompute
-        # the nearest neighbors, so it should raise an error
+        # Raising the perplexity above the number of neighbors in the kNN graph
+        # would need to recompute the nearest neighbors, so it should raise an error
         with self.assertRaises(RuntimeError):
-            aff.set_perplexity(30)
+            aff.set_perplexity(70)
 
 
 class TestMultiscale(unittest.TestCase):


### PR DESCRIPTION
This should implement my suggestion in #156.

I checked and it seems to work as expected. 

However, notice that I changed the logic in `to_new` and in `set_perplexity` a little, to make it consistent with `k_neighbors` that could possibly be user-provided. For simplicity, I made these functions always use the same originally provided or computed `k_neighbors` neighbors. So e.g. if the original affinity is computed with `perplexity=20, k_neighbors=25`, then `to_new(perplexity=10)` will use the same `k_neighbors=25`. Previously your code would have used 3*10=30 in this case (which won't work in this particular situation because 25<30).

The same for `set_perplexity`. 

This may result in some loss of efficiency, but I thought it's probably negligible. Let me know what you think.