### PR TITLE
Add sklearn nearest_neighbor search with method="auto"

### DIFF
--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -288,12 +288,12 @@ def build_knn_index(
         preferred_approx_method = nearest_neighbors.NNDescent
 
     if data.shape[0] < 1000:
-        preferred_method = nearest_neighbors.BallTree
+        preferred_method = nearest_neighbors.Sklearn
     else:
         preferred_method = preferred_approx_method
 
     methods = {
-        "exact": nearest_neighbors.BallTree,
+        "exact": nearest_neighbors.Sklearn,
         "auto": preferred_method,
         "approx": preferred_approx_method,
         "annoy": nearest_neighbors.Annoy,

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -202,6 +202,12 @@ class BallTree(KNNIndex):
         super().__init__(*args, **kwargs)
         self.__data = None
 
+        warnings.warn(
+            f"`nearest_neighbors.BallTree` has been superseeded by "
+            f"`nearest_neighbors.Sklearn` and will be removed from future versions",
+            category=FutureWarning,
+        )
+
     def build(self, data, k):
         timer = utils.Timer(
             f"Finding {k} nearest neighbors using exact search using "

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -139,6 +139,10 @@ class TestBallTree(KNNIndexTestMixin, unittest.TestCase):
         )
 
 
+class TestSklearn(TestBallTree):
+    pass
+
+
 @unittest.skipIf(not is_package_installed("hnswlib"), "`hnswlib`is not installed")
 class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
     knn_index = nearest_neighbors.HNSW

--- a/tests/test_tsne.py
+++ b/tests/test_tsne.py
@@ -562,7 +562,7 @@ class TestRandomState(unittest.TestCase):
         )
 
     @patch("openTSNE.initialization.random", wraps=openTSNE.initialization.random)
-    @patch("openTSNE.nearest_neighbors.BallTree", wraps=openTSNE.nearest_neighbors.BallTree)
+    @patch("openTSNE.nearest_neighbors.Sklearn", wraps=openTSNE.nearest_neighbors.Sklearn)
     def test_random_state_parameter_is_propagated_random_init_exact(self, init, neighbors):
         random_state = 1
 


### PR DESCRIPTION
##### Issue
#162


##### Description of changes
I initially thought we could get rid of all the cosine distance logic, but it turns out that scikit-learn doesn't implement it. So that workaround stays. Basically, this is just a copy of `BallTree`, but with `method="auto"`.

I've also deprecated `BallTree`, which will be removed in future versions. Then, we can also get rid of this code duplication.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
