### PR TITLE
Fix circular clipping

### DIFF
--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -1402,7 +1402,7 @@ def kl_divergence_fft(
         if reference_embedding is not None:
             sum_Q = _tsne.estimate_negative_gradient_fft_1d_with_grid(
                 embedding.ravel(),
-                reference_embedding.ravel(),
+                gradient.ravel(),
                 reference_embedding.interp_coeffs,
                 reference_embedding.box_x_lower_bounds,
                 fft_params["n_interpolation_points"],

--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -1725,7 +1725,7 @@ class gradient_descent:
             # Limit any new points within the circle defined by the interpolation grid
             if should_limit_range:
                 if embedding.shape[1] == 1:
-                    mask = (lower_limit < embedding) & (embedding < upper_limit)
+                    mask = (embedding < lower_limit) | (embedding > upper_limit)
                     np.clip(embedding, lower_limit, upper_limit, out=embedding)
                 elif embedding.shape[1] == 2:
                     r_limit = max(abs(lower_limit), abs(upper_limit))

--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -1728,13 +1728,9 @@ class gradient_descent:
                     mask = (lower_limit < embedding) & (embedding < upper_limit)
                     np.clip(embedding, lower_limit, upper_limit, out=embedding)
                 elif embedding.shape[1] == 2:
-                    r = np.linalg.norm(embedding, axis=1)
-                    phi = np.arctan2(embedding[:, 0], embedding[:, 1])
                     r_limit = max(abs(lower_limit), abs(upper_limit))
-                    mask = r > r_limit
-                    np.clip(r, 0, r_limit, out=r)
-                    embedding[:, 0] = r * np.cos(phi)
-                    embedding[:, 1] = r * np.sin(phi)
+                    embedding, mask = utils.clip_point_to_disc(embedding, r_limit, inplace=True)
+
                 # Zero out the momentum terms for the points that hit the boundary
                 self.gains[~mask] = 0
 

--- a/openTSNE/utils.py
+++ b/openTSNE/utils.py
@@ -1,6 +1,7 @@
 from functools import wraps
 from time import time
 import warnings
+import numpy as np
 
 
 class Timer:
@@ -43,3 +44,17 @@ def is_package_installed(libname):
         return True
     except ImportError:
         return False
+
+
+def clip_point_to_disc(points, radius, inplace=False):
+    if not inplace:
+        points = points.copy()
+
+    r = np.linalg.norm(points, axis=1)
+    phi = np.arctan2(points[:, 0], points[:, 1])
+    mask = r > radius
+    np.clip(r, 0, radius, out=r)
+    points[:, 0] = r * np.sin(phi)
+    points[:, 1] = r * np.cos(phi)
+
+    return points, mask

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+import unittest
+import numpy as np
+
+from openTSNE.utils import clip_point_to_disc
+
+
+class TestClipping(unittest.TestCase):
+    def test_circular_clip_do_nothing(self):
+        x = np.array([[0, 1], [1, 0], [0.05, 0.05]], dtype=np.float64)
+        x_clipped, mask = clip_point_to_disc(x, 1)
+        np.testing.assert_almost_equal(x, x_clipped)
+        np.testing.assert_almost_equal(mask, [0, 0, 0])
+
+    def test_circular_clip_do_clipping1(self):
+        x = np.array([[0, 1], [5, 0], [0.05, 0.05]], dtype=np.float64)
+        x_clipped, mask = clip_point_to_disc(x, 1)
+        np.testing.assert_almost_equal([[0, 1], [1, 0], [0.05, 0.05]], x_clipped)
+        np.testing.assert_almost_equal(mask, [0, 1, 0])
+
+    def test_circular_clip_do_clipping2(self):
+        x = np.array([[0, 1], [1, 0], [1, 1]], dtype=np.float64)
+        x_clipped, mask = clip_point_to_disc(x, 1)
+        v = np.cos(np.radians(45))
+        np.testing.assert_almost_equal([[0, 1], [1, 0], [v, v]], x_clipped)
+        np.testing.assert_almost_equal(mask, [0, 0, 1])


### PR DESCRIPTION
##### Issue
Apparently, there I had made a mistake in the previous "fix" of circular clipping. This here should really fix it once and for all.

##### Description of changes
- Fix gradient clipping
- I found another bug in 1d FFT gradients when using precomputed grids.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
