### PR TITLE
Add missing references to hnsw neighbors method

### DIFF
--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -470,7 +470,7 @@ class FixedSigmaNN(Affinities):
 
     method: str
         Specifies the nearest neighbor method to use. Can be ``exact``, ``annoy``,
-        ``pynndescent``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
+        ``pynndescent``, ``hnsw``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
         if the input data matrix is not a sparse object and if Annoy supports
         the given metric. Otherwise it uses Pynndescent. ``auto`` uses exact
         nearest neighbors for N<1000 and the same heuristic as ``approx`` for N>=1000.

--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -1065,7 +1065,7 @@ class TSNE(BaseEstimator):
 
     neighbors: str
         Specifies the nearest neighbor method to use. Can be ``exact``, ``annoy``,
-        ``pynndescent``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
+        ``pynndescent``, ``hnsw``, ``approx``, or ``auto`` (default). ``approx`` uses Annoy
         if the input data matrix is not a sparse object and if Annoy supports
         the given metric. Otherwise it uses Pynndescent. ``auto`` uses exact
         nearest neighbors for N<1000 and the same heuristic as ``approx`` for N>=1000.


### PR DESCRIPTION
##### Description of changes
Fixes #171.
Adds missing mentions of hnsw in relevant docstrings.

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
