### PR TITLE
Support precomputed distance matrices

### DIFF
--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -1318,8 +1318,17 @@ class TSNE(BaseEstimator):
         if X is None and initialization == "pca":
             log.warning(
                 "Attempting to use `pca` initalization, but no `X` matrix specified! "
-                "Using `spectral` initilization instead, which requires only "
-                "`affinities`."
+                "Using `spectral` initilization instead, which doesn't need access "
+                "to the data matrix"
+            )
+            initialization = "spectral"
+
+        # Same spiel for precomputed distance matrices
+        if self.metric == "precomputed" and initialization == "pca":
+            log.warning(
+                "Attempting to use `pca` initalization, but using precomputed "
+                "distance matrix! Using `spectral` initilization instead, which "
+                "doesn't need access to the data matrix."
             )
             initialization = "spectral"
 

--- a/tests/test_tsne.py
+++ b/tests/test_tsne.py
@@ -387,25 +387,52 @@ class TestTSNECallbackParams(unittest.TestCase):
         self.assertEqual(callback.call_count, 1)
 
 
-class TestAffinityAsParameter(unittest.TestCase):
-    def test_fails_if_incorrect_class(self):
-        aff = "definitely not an instance of Affinity"
+class TestAlternativeFitUsageWithAffinityAndInitialization(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.x = np.random.normal(100, 50, (25, 4))
+        cls.init = np.random.normal(0, 1e-4, (25, 2))
+
+    def test_fails_if_no_parameters_specified(self):
+        tsne = TSNE()
         with self.assertRaises(ValueError):
-            TSNE(affinities=aff)
+            tsne.fit()
 
-    def test_affinities_passed_to_embedding(self):
-        x = np.random.normal(100, 50, (25, 4))
-        aff = affinity.PerplexityBasedNN(x, 5, method="exact")
-        tsne = TSNE(affinities=aff)
-        embedding = tsne.prepare_initial(x)
+    def test_precomputed_affinity_is_passed_to_embedding_object(self):
+        aff = affinity.PerplexityBasedNN(self.x, 5, method="exact")
+        embedding = TSNE(
+            early_exaggeration_iter=0, n_iter=0, initialization=self.init
+        ).fit(affinities=aff)
         self.assertIs(embedding.affinities, aff)
 
-    def test_optimize_runs_properly(self):
-        x = np.random.normal(100, 50, (25, 4))
-        aff = affinity.PerplexityBasedNN(x, 5, method="exact")
-        tsne = TSNE(affinities=aff)
-        embedding = tsne.fit(x)
-        self.assertIs(embedding.affinities, aff)
+    def test_fails_if_affinities_parameter_is_not_correct_class(self):
+        aff = "definitely not an affinity object"
+        with self.assertRaises(ValueError):
+            TSNE(initialization=self.init).fit(affinities=aff)
+
+    def test_precomputed_initialization_is_passed_to_embedding_object(self):
+        embedding = TSNE(early_exaggeration_iter=0, n_iter=0) \
+            .fit(self.x, initialization=self.init)
+        np.testing.assert_array_equal(embedding, self.init)
+
+    def test_string_initialization(self):
+        # This should not crash
+        TSNE(early_exaggeration_iter=0, n_iter=0).fit(self.x, initialization="pca")
+
+    def test_parameter_init_takes_precendence_over_constructor_init(self):
+        constructor_init = np.random.normal(1, 1e-4, self.init.shape)
+        embedding = TSNE(
+            early_exaggeration_iter=0, n_iter=0, initialization=constructor_init
+        ).fit(self.x, initialization=self.init)
+        np.testing.assert_array_equal(embedding, self.init)
+
+    def test_pca_init_with_only_affinities_passed(self):
+        aff = affinity.PerplexityBasedNN(self.x, 5, method="exact")
+        desired_init = initialization.spectral(aff.P)
+        embedding = TSNE(
+            early_exaggeration_iter=0, n_iter=0, initialization="pca"
+        ).fit(affinities=aff)
+        np.testing.assert_array_equal(embedding, desired_init)
 
 
 class TSNEInitialization(unittest.TestCase):


### PR DESCRIPTION
##### Description of changes
Fixes #170.

- Change API for `KNNIndex.__init__` and `KNNIndex.build` so that `data` and `k` are specified in the constructor. This makes more sense in light of the precomputed distance class. This is against what I usually say, that the API needs to be backwards compatible, but I strongly suspect this is so deep within the library that nobody has ever done anything with it. So I think it should be okay here.
- Change API for `TSNE.__init__` and `TSNE.fit`, removing the `affinities` parameter from the constructor. This lead to some very strange function calls. We now change `.fit` so that either a data matrix can be passed in, or an affinity object. Optionally, the user can specify the initialization as well. Same goes for `prepare_partial`. Again, this is such niche usage, I doubt anyone will have problems with this.
- Adds support for precomputed distance matrices

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
