### PR TITLE
Implement precomputed affinity class

### DIFF
--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -1264,3 +1264,22 @@ class Uniform(Affinities):
             return P, neighbors, distances
 
         return P
+
+
+class PrecomputedAffinities(Affinities):
+    """Use a precomputed affinity matrix.
+
+    Parameters
+    ----------
+    affinities: scipy.sparse.csr_matrix, np.ndarray
+        A N x N matrix containing the affinities.
+
+    """
+
+    def __init__(self, affinities):
+        if not isinstance(affinities, sp.csr_matrix):
+            affinities = sp.csr_matrix(affinities)
+        self.P = affinities
+
+    def to_new(self, data, return_distances=False):
+        raise RuntimeError("Precomputed affinity matrices cannot be queried.")

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -1273,12 +1273,16 @@ class PrecomputedAffinities(Affinities):
     ----------
     affinities: scipy.sparse.csr_matrix, np.ndarray
         A N x N matrix containing the affinities.
+    normalize: bool
+        Normalize the affinity matrix to sum to 1. Default is True.
 
     """
 
-    def __init__(self, affinities):
+    def __init__(self, affinities, normalize=True):
         if not isinstance(affinities, sp.csr_matrix):
             affinities = sp.csr_matrix(affinities)
+        if normalize:
+            affinities /= np.sum(affinities)
         self.P = affinities
 
     def to_new(self, data, return_distances=False):

--- a/tests/test_affinities.py
+++ b/tests/test_affinities.py
@@ -348,7 +348,7 @@ class TestPrecomputedAffinity(unittest.TestCase):
 
     def test_precomputed_affinity_matches(self):
         aff1 = PerplexityBasedNN(self.iris)
-        aff2 = affinity.PrecomputedAffinity(aff1.P)
+        aff2 = affinity.PrecomputedAffinities(aff1.P)
         np.testing.assert_allclose(
             aff1.P.toarray(),
             aff2.P.toarray(),
@@ -357,7 +357,7 @@ class TestPrecomputedAffinity(unittest.TestCase):
 
     def test_precomputed_affinity_normalization(self):
         aff1 = PerplexityBasedNN(self.iris)
-        aff2 = affinity.PrecomputedAffinity(aff1.P * 2)
+        aff2 = affinity.PrecomputedAffinities(aff1.P * 2)
         np.testing.assert_allclose(
             aff1.P.toarray(),
             aff2.P.toarray(),

--- a/tests/test_affinities.py
+++ b/tests/test_affinities.py
@@ -345,17 +345,21 @@ class TestPrecomputedAffinity(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.iris = datasets.load_iris().data
-    
+
     def test_precomputed_affinity_matches(self):
         aff1 = PerplexityBasedNN(self.iris)
         aff2 = affinity.PrecomputedAffinity(aff1.P)
-        np.testing.assert_almost_equal(
-            aff1.P.toarray(), aff2.P.toarray(), err_msg=method_name
+        np.testing.assert_allclose(
+            aff1.P.toarray(),
+            aff2.P.toarray(),
+            err_msg="Precomputed affinities are not passed in correctly.",
         )
 
     def test_precomputed_affinity_normalization(self):
         aff1 = PerplexityBasedNN(self.iris)
         aff2 = affinity.PrecomputedAffinity(aff1.P * 2)
-        np.testing.assert_almost_equal(
-            aff1.P.toarray(), aff2.P.toarray(), err_msg=method_name
+        np.testing.assert_allclose(
+            aff1.P.toarray(),
+            aff2.P.toarray(),
+            err_msg="Precomputed affinities are not normalized to sum to 1.",
         )

--- a/tests/test_affinities.py
+++ b/tests/test_affinities.py
@@ -340,3 +340,22 @@ class TestAffinityAcceptsKnnIndexAsParameter(unittest.TestCase):
         for method_name, cls in AFFINITY_CLASSES:
             aff = cls(knn_index=knn_index)
             aff.to_new(self.iris)
+
+class TestPrecomputedAffinity(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.iris = datasets.load_iris().data
+    
+    def test_precomputed_affinity_matches(self):
+        aff1 = PerplexityBasedNN(self.iris)
+        aff2 = affinity.PrecomputedAffinity(aff1.P)
+        np.testing.assert_almost_equal(
+            aff1.P.toarray(), aff2.P.toarray(), err_msg=method_name
+        )
+
+    def test_precomputed_affinity_normalization(self):
+        aff1 = PerplexityBasedNN(self.iris)
+        aff2 = affinity.PrecomputedAffinity(aff1.P * 2)
+        np.testing.assert_almost_equal(
+            aff1.P.toarray(), aff2.P.toarray(), err_msg=method_name
+        )

--- a/tests/test_different_usages.py
+++ b/tests/test_different_usages.py
@@ -109,6 +109,15 @@ class TestUsageWithCustomAffinity(TestUsage):
             new_embedding.optimize(10, learning_rate=0.1, inplace=True)
             self.eval_embedding(new_embedding, self.y, f"transform::{aff.__class__.__name__}")
 
+    def test_precomputed_affinity(self):
+        # Setup precomputed affinity
+        aff = affinity.Uniform(self.x).P
+        aff *= 10  # rescale
+        precomputed_affinity = affinity.PrecomputedAffinities(aff, normalize=True)
+
+        embedding = TSNE().fit(affinities=precomputed_affinity, initialization="spectral")
+        self.eval_embedding(embedding, self.y, aff.__class__.__name__)
+
 
 class TestUsageWithCustomAffinityAndCustomNeighbors(TestUsage):
     def test_affinity_with_queryable_knn_index(self):


### PR DESCRIPTION
Implements #216.

Allows to do the following:
```python
from openTSNE import TSNE
from openTSNE.affinity import PrecomputedAffinities

# Here P is either a np.array or a scipy.sparse matrix
Z = TSNE().fit(affinities = PrecomputedAffinities(P))
```