### PR TITLE
Implement auto early exaggeration

### DIFF
--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -1007,7 +1007,7 @@ class TSNE(BaseEstimator):
         The exaggeration factor to use during the *early exaggeration* phase.
         Typical values range from 4 to 32. When ``early_exaggeration="auto"``
         early exaggeration factor defaults to 12, unless desired subsequent
-        exaggeration is higher, i.e.: ``early_exaggeration = min(12,
+        exaggeration is higher, i.e.: ``early_exaggeration = max(12,
         exaggeration)``.
 
     n_iter: int
@@ -1152,7 +1152,10 @@ class TSNE(BaseEstimator):
         self.perplexity = perplexity
         self.learning_rate = learning_rate
         if early_exaggeration == "auto":
-            self.early_exaggeration = min(12, exaggeration)
+            if exaggeration is None:
+                self.early_exaggeration = 12
+            else:
+                self.early_exaggeration = max(12, exaggeration)
         else:
             self.early_exaggeration = early_exaggeration
         self.early_exaggeration_iter = early_exaggeration_iter

--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -88,8 +88,13 @@ def _handle_nice_params(embedding: np.ndarray, optim_params: dict) -> None:
     optim_params["n_jobs"] = n_jobs
 
     # Determine learning rate if requested
-    if optim_params.get("learning_rate", "auto") == "auto":
-        optim_params["learning_rate"] = max(200, n_samples / 12)
+    learning_rate = optim_params.get("learning_rate", "auto")
+    if learning_rate == "auto":
+        exaggeration = optim_params.get("exaggeration", None)
+        if exaggeration is None:
+            exaggeration = 1
+        learning_rate = n_samples / exaggeration
+    optim_params["learning_rate"] = learning_rate
 
 
 def __check_init_num_samples(num_samples, required_num_samples):
@@ -160,11 +165,12 @@ class PartialTSNEEmbedding(np.ndarray):
 
     learning_rate: Union[str, float]
         The learning rate for t-SNE optimization. When ``learning_rate="auto"``
-        the appropriate learning rate is selected according to max(200, N / 12)
+        the appropriate learning rate is selected according to N / exaggeration
         as determined in Belkina et al. (2019), Nature Communications. Note that
-        this should *not* be used when adding samples into existing embeddings,
-        where the learning rate often needs to be much lower to obtain
-        convergence.
+        this will result in a different learning rate during the early
+        exaggeration phase and afterwards. This should *not* be used when 
+        adding samples into existing embeddings, where the learning rate often
+        needs to be much lower to obtain convergence.
 
     exaggeration: float
         The exaggeration factor is used to increase the attractive forces of
@@ -278,14 +284,14 @@ class PartialTSNEEmbedding(np.ndarray):
             The number of optimization iterations.
 
         learning_rate: Union[str, float]
-            The learning rate for t-SNE optimization. When
+            The learning rate for t-SNE optimization. When 
             ``learning_rate="auto"`` the appropriate learning rate is selected
-            according to max(200, N / 12), as determined in Belkina et al.
-            "Automated optimized parameters for t-distributed stochastic
-            neighbor embedding improve visualization and analysis of large
-            datasets", 2019. Note that this should *not* be used when adding
-            samples into existing embeddings, where the learning rate often
-            needs to be much lower to obtain convergence.
+            according to N / exaggeration as determined in Belkina et al.
+            (2019), Nature Communications. Note that this will result in a
+            different learning rate during the early exaggeration phase and
+            afterwards. This should *not* be used when adding samples into
+            existing embeddings, where the learning rate often needs to be much
+            lower to obtain convergence.
 
         exaggeration: float
             The exaggeration factor is used to increase the attractive forces of
@@ -414,10 +420,12 @@ class TSNEEmbedding(np.ndarray):
 
     learning_rate: Union[str, float]
         The learning rate for t-SNE optimization. When ``learning_rate="auto"``
-        the appropriate learning rate is selected according to max(200, N / 12),
-        as determined in Belkina et al. "Automated optimized parameters for
-        T-distributed stochastic neighbor embedding improve visualization and
-        analysis of large datasets", 2019.
+        the appropriate learning rate is selected according to N / exaggeration
+        as determined in Belkina et al. (2019), Nature Communications. Note that
+        this will result in a different learning rate during the early
+        exaggeration phase and afterwards. This should *not* be used when 
+        adding samples into existing embeddings, where the learning rate often
+        needs to be much lower to obtain convergence.
 
     exaggeration: float
         The exaggeration factor is used to increase the attractive forces of
@@ -552,12 +560,14 @@ class TSNEEmbedding(np.ndarray):
             The number of optimization iterations.
 
         learning_rate: Union[str, float]
-            The learning rate for t-SNE optimization. When
+            The learning rate for t-SNE optimization. When 
             ``learning_rate="auto"`` the appropriate learning rate is selected
-            according to max(200, N / 12), as determined in Belkina et al.
-            "Automated optimized parameters for t-distributed stochastic
-            neighbor embedding improve visualization and analysis of large
-            datasets", 2019.
+            according to N / exaggeration as determined in Belkina et al.
+            (2019), Nature Communications. Note that this will result in a
+            different learning rate during the early exaggeration phase and
+            afterwards. This should *not* be used when adding samples into
+            existing embeddings, where the learning rate often needs to be much
+            lower to obtain convergence.
 
         exaggeration: float
             The exaggeration factor is used to increase the attractive forces of
@@ -693,7 +703,7 @@ class TSNEEmbedding(np.ndarray):
         early_exaggeration_iter=0,
         exaggeration=1.5,
         n_iter=250,
-        initial_momentum=0.5,
+        initial_momentum=0.8,
         final_momentum=0.8,
         max_grad_norm=0.25,
         max_step_norm=None,
@@ -731,21 +741,21 @@ class TSNEEmbedding(np.ndarray):
             initial point positions.
 
         learning_rate: Union[str, float]
-            The learning rate for t-SNE optimization. When
+            The learning rate for t-SNE optimization. When 
             ``learning_rate="auto"`` the appropriate learning rate is selected
-            according to max(200, N / 12), as determined in Belkina et al.
-            "Automated optimized parameters for t-distributed stochastic
-            neighbor embedding improve visualization and analysis of large
-            datasets", 2019. Note that this should *not* be used when adding
-            samples into existing embeddings, where the learning rate often
-            needs to be much lower to obtain convergence.
+            according to N / exaggeration as determined in Belkina et al.
+            (2019), Nature Communications. Note that this will result in a
+            different learning rate during the early exaggeration phase and
+            afterwards. This should *not* be used when adding samples into
+            existing embeddings, where the learning rate often needs to be much
+            lower to obtain convergence.
 
         early_exaggeration_iter: int
             The number of iterations to run in the *early exaggeration* phase.
 
         early_exaggeration: float
             The exaggeration factor to use during the *early exaggeration* phase.
-            Typical values range from 12 to 32.
+            Typical values range from 4 to 32.
 
         n_iter: int
             The number of iterations to run in the normal optimization regime.
@@ -995,10 +1005,12 @@ class TSNE(BaseEstimator):
 
     learning_rate: Union[str, float]
         The learning rate for t-SNE optimization. When ``learning_rate="auto"``
-        the appropriate learning rate is selected according to ``max(200,
-        N/early_exaggeration),`` as determined in Belkina et al. "Automated 
-        optimized parameters for T-distributed stochastic neighbor embedding 
-        improve visualization and analysis of large datasets", 2019.
+        the appropriate learning rate is selected according to N / exaggeration
+        as determined in Belkina et al. (2019), Nature Communications. Note that
+        this will result in a different learning rate during the early
+        exaggeration phase and afterwards. This should *not* be used when 
+        adding samples into existing embeddings, where the learning rate often
+        needs to be much lower to obtain convergence.
 
     early_exaggeration_iter: int
         The number of iterations to run in the *early exaggeration* phase.
@@ -1136,7 +1148,7 @@ class TSNE(BaseEstimator):
         initialization="pca",
         metric="euclidean",
         metric_params=None,
-        initial_momentum=0.5,
+        initial_momentum=0.8,
         final_momentum=0.8,
         max_grad_norm=None,
         max_step_norm=5,
@@ -1404,17 +1416,11 @@ class TSNE(BaseEstimator):
             raise ValueError(
                 f"Unrecognized initialization scheme `{initialization}`."
             )
-            
-        # Set the auto learning rate depending on the value of early exaggeration
-        if self.learning_rate == "auto":
-            learning_rate_now = max(200, n_samples / self.early_exaggeration)
-        else:
-            learning_rate_now = self.learning_rate 
 
         gradient_descent_params = {
             "dof": self.dof,
             "negative_gradient_method": self.negative_gradient_method,
-            "learning_rate": learning_rate_now,
+            "learning_rate": self.learning_rate,
             # By default, use the momentum used in unexaggerated phase
             "momentum": self.final_momentum,
             # Barnes-Hut params
@@ -1582,8 +1588,8 @@ class gradient_descent:
         P,
         n_iter,
         objective_function,
-        learning_rate=200,
-        momentum=0.5,
+        learning_rate="auto",
+        momentum=0.8,
         exaggeration=None,
         dof=1,
         min_gain=0.01,
@@ -1618,12 +1624,14 @@ class gradient_descent:
             embedding.
 
         learning_rate: Union[str, float]
-            The learning rate for t-SNE optimization. When
+            The learning rate for t-SNE optimization. When 
             ``learning_rate="auto"`` the appropriate learning rate is selected
-            according to max(200, N / 12), as determined in Belkina et al.
-            "Automated optimized parameters for t-distributed stochastic
-            neighbor embedding improve visualization and analysis of large
-            datasets", 2019.
+            according to N / exaggeration as determined in Belkina et al.
+            (2019), Nature Communications. Note that this will result in a
+            different learning rate during the early exaggeration phase and
+            afterwards. This should *not* be used when adding samples into
+            existing embeddings, where the learning rate often needs to be much
+            lower to obtain convergence.
 
         momentum: float
             Momentum accounts for gradient directions from previous iterations,

--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -284,7 +284,7 @@ class PartialTSNEEmbedding(np.ndarray):
             The number of optimization iterations.
 
         learning_rate: Union[str, float]
-            The learning rate for t-SNE optimization. When 
+            The learning rate for t-SNE optimization. When
             ``learning_rate="auto"`` the appropriate learning rate is selected
             according to N / exaggeration as determined in Belkina et al.
             (2019), Nature Communications. Note that this will result in a
@@ -560,7 +560,7 @@ class TSNEEmbedding(np.ndarray):
             The number of optimization iterations.
 
         learning_rate: Union[str, float]
-            The learning rate for t-SNE optimization. When 
+            The learning rate for t-SNE optimization. When
             ``learning_rate="auto"`` the appropriate learning rate is selected
             according to N / exaggeration as determined in Belkina et al.
             (2019), Nature Communications. Note that this will result in a
@@ -1624,7 +1624,7 @@ class gradient_descent:
             embedding.
 
         learning_rate: Union[str, float]
-            The learning rate for t-SNE optimization. When 
+            The learning rate for t-SNE optimization. When
             ``learning_rate="auto"`` the appropriate learning rate is selected
             according to N / exaggeration as determined in Belkina et al.
             (2019), Nature Communications. Note that this will result in a

--- a/tests/test_different_usages.py
+++ b/tests/test_different_usages.py
@@ -190,7 +190,7 @@ class TestUsageExplicitOptimizeCalls(TestUsage):
         embedding2 = embedding2.optimize(n_iter=250, exaggeration=12)
         embedding2 = embedding2.optimize(n_iter=500, exaggeration=1)
         
-        self.assert_array_equal(
+        np.testing.assert_array_equal(
             embedding1,
             embedding2,
             "Calling optimize twice with default parameters produced a different " \

--- a/tests/test_different_usages.py
+++ b/tests/test_different_usages.py
@@ -67,7 +67,7 @@ class TestUsageLowestLevel(TestUsage):
         init = initialization.pca(self.x)
         aff = affinity.PerplexityBasedNN(self.x, perplexity=30)
         embedding = openTSNE.TSNEEmbedding(init, aff)
-        embedding.optimize(25, exaggeration=12, momentum=0.5, inplace=True)
+        embedding.optimize(25, exaggeration=12, momentum=0.8, inplace=True)
         embedding.optimize(50, exaggeration=1, momentum=0.8, inplace=True)
         self.eval_embedding(embedding, self.y)
         new_embedding = embedding.transform(self.x)
@@ -77,7 +77,7 @@ class TestUsageLowestLevel(TestUsage):
         init = initialization.pca(self.x)
         aff = affinity.MultiscaleMixture(self.x, perplexities=[5, 30])
         embedding = openTSNE.TSNEEmbedding(init, aff)
-        embedding.optimize(25, exaggeration=12, momentum=0.5, inplace=True)
+        embedding.optimize(25, exaggeration=12, momentum=0.8, inplace=True)
         embedding.optimize(50, exaggeration=1, momentum=0.8, inplace=True)
         self.eval_embedding(embedding, self.y)
         new_embedding = embedding.transform(self.x)
@@ -187,8 +187,8 @@ class TestUsageExplicitOptimizeCalls(TestUsage):
         A = affinity.PerplexityBasedNN(self.x)
         I = initialization.pca(self.x)
         embedding2 = TSNEEmbedding(I, A)
-        embedding2 = embedding2.optimize(n_iter=250, exaggeration=12)
-        embedding2 = embedding2.optimize(n_iter=500, exaggeration=1)
+        embedding2 = embedding2.optimize(n_iter=25, exaggeration=12)
+        embedding2 = embedding2.optimize(n_iter=50)
         
         np.testing.assert_array_equal(
             embedding1,

--- a/tests/test_different_usages.py
+++ b/tests/test_different_usages.py
@@ -178,3 +178,21 @@ class TestUsageWithCustomAffinityAndCustomNeighbors(TestUsage):
             # With initilization
             embedding = TSNE().fit(affinities=aff, initialization=init)
             self.eval_embedding(embedding, self.y, aff.__class__.__name__)
+
+
+class TestUsageExplicitOptimizeCalls(TestUsage):
+    def test_explicit_optimize_calls(self):
+        embedding1 = TSNE().fit(self.x)
+        
+        A = affinity.PerplexityBasedNN(self.x)
+        I = initialization.pca(self.x)
+        embedding2 = TSNEEmbedding(I, A)
+        embedding2.optimize(n_iter=250, exaggeration=12)
+        embedding2.optimize(n_iter=500, exaggeration=1)
+        
+        self.assert_array_equal(
+            embedding1,
+            embedding2,
+            "Calling optimize twice with default parameters produced a different " \
+            "result compared to the default optimization"
+        )

--- a/tests/test_different_usages.py
+++ b/tests/test_different_usages.py
@@ -187,12 +187,12 @@ class TestUsageExplicitOptimizeCalls(TestUsage):
         A = affinity.PerplexityBasedNN(self.x)
         I = initialization.pca(self.x)
         embedding2 = TSNEEmbedding(I, A)
-        embedding2.optimize(n_iter=250, exaggeration=12)
-        embedding2.optimize(n_iter=500, exaggeration=1)
+        embedding2 = embedding2.optimize(n_iter=250, exaggeration=12)
+        embedding2 = embedding2.optimize(n_iter=500, exaggeration=1)
         
         self.assert_array_equal(
             embedding1,
             embedding2,
             "Calling optimize twice with default parameters produced a different " \
-            "result compared to the default optimization"
+            "result compared to the default fit() call"
         )

--- a/tests/test_different_usages.py
+++ b/tests/test_different_usages.py
@@ -8,7 +8,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.neighbors import KNeighborsClassifier, NearestNeighbors
 
 import openTSNE
-from openTSNE import affinity, initialization, nearest_neighbors
+from openTSNE import affinity, initialization, nearest_neighbors, TSNEEmbedding
 
 Multiscale = partial(affinity.Multiscale, method="exact")
 MultiscaleMixture = partial(affinity.MultiscaleMixture, method="exact")


### PR DESCRIPTION
Implements #218.

First, `early_exaggeration="auto"` is now set to `max(12, exaggeration)`.

Second, the learning rate. We have various functions that currently take `learning_rate="auto"` and set it to `max(200, N/12)`. I did not change this, because those functions usually do not know what the early exaggeration was. So I kept it as is. I only changed the behaviour of the base class: there `learning_rate="auto"` is now set to `max(200, N/early_exaggeration)`.

This works as intended:

```Python
X = np.random.randn(10000,10)

TSNE(verbose=True).fit(X)
# Prints 
# TSNE(early_exaggeration=12, verbose=True)
# Uses lr=833.33

TSNE(verbose=True, exaggeration=5).fit(X)
# Prints
# TSNE(early_exaggeration=12, exaggeration=5, verbose=True)
# Uses lr=833.33

TSNE(verbose=True, exaggeration=20).fit(X)
# Prints
# TSNE(early_exaggeration=20, exaggeration=20, verbose=True)
# Uses lr=500.00
```

(Note that the learning rate is currently not printed by the `repr(self)` because it's kept as "auto" at construction time and only set later. That's also how we had it before.)
