### PR TITLE
Fix inplace optimization changing init (in some cases)

### DIFF
--- a/openTSNE/tsne.py
+++ b/openTSNE/tsne.py
@@ -35,7 +35,7 @@ def _check_callbacks(callbacks):
 
 
 def _handle_nice_params(embedding: np.ndarray, optim_params: dict) -> None:
-    """Convert the user friendly params into something the optimizer can
+    """Convert the user-friendly params into something the optimizer can
     understand."""
     n_samples = embedding.shape[0]
     # Handle callbacks
@@ -43,8 +43,7 @@ def _handle_nice_params(embedding: np.ndarray, optim_params: dict) -> None:
     optim_params["use_callbacks"] = optim_params["callbacks"] is not None
 
     # Handle negative gradient method
-    negative_gradient_method = optim_params.pop("negative_gradient_method")
-    # Handle `auto` negative gradient method
+    negative_gradient_method = optim_params.pop("negative_gradient_method", "auto")
     if isinstance(negative_gradient_method, str) and negative_gradient_method == "auto":
         if n_samples < 10_000:
             negative_gradient_method = "bh"
@@ -248,9 +247,7 @@ class PartialTSNEEmbedding(np.ndarray):
     ):
         init_checks.num_samples(embedding.shape[0], P.shape[0])
 
-        obj = np.asarray(embedding, dtype=np.float64, order="C").view(
-            PartialTSNEEmbedding
-        )
+        obj = np.array(embedding, dtype=np.float64, order="C").view(PartialTSNEEmbedding)
 
         obj.reference_embedding = reference_embedding
         obj.P = P
@@ -512,7 +509,7 @@ class TSNEEmbedding(np.ndarray):
     ):
         init_checks.num_samples(embedding.shape[0], affinities.P.shape[0])
 
-        obj = np.asarray(embedding, dtype=np.float64, order="C").view(TSNEEmbedding)
+        obj = np.array(embedding, dtype=np.float64, order="C").view(TSNEEmbedding)
 
         obj.affinities = affinities  # type: Affinities
         obj.gradient_descent_params = gradient_descent_params  # type: dict

--- a/tests/test_tsne.py
+++ b/tests/test_tsne.py
@@ -18,7 +18,9 @@ from openTSNE import affinity
 from openTSNE import initialization
 from openTSNE.affinity import PerplexityBasedNN
 from openTSNE.nearest_neighbors import NNDescent
-from openTSNE.tsne import kl_divergence_bh, kl_divergence_fft
+from openTSNE.tsne import (
+    kl_divergence_bh, kl_divergence_fft, TSNEEmbedding, PartialTSNEEmbedding
+)
 from openTSNE.utils import is_package_installed
 
 np.random.seed(42)
@@ -274,8 +276,9 @@ class TestTSNEInplaceOptimization(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tsne = TSNE()
-        cls.x = np.random.randn(100, 4)
-        cls.x_test = np.random.randn(25, 4)
+        cls.x = datasets.load_iris()["data"]
+        cls.x_test = cls.x[::3]
+        cls.x_test += np.random.normal(0, 1, size=cls.x_test.shape)
 
     def test_embedding_inplace_optimization(self):
         embedding1 = self.tsne.prepare_initial(self.x)
@@ -320,6 +323,38 @@ class TestTSNEInplaceOptimization(unittest.TestCase):
         self.assertFalse(partial_embedding1.base is partial_embedding2.base)
         self.assertFalse(partial_embedding2.base is partial_embedding3.base)
         self.assertFalse(partial_embedding1.base is partial_embedding3.base)
+
+    def test_inplace_embedding_optimization_doesnt_change_init(self):
+        init = initialization.pca(self.x)
+        init_copy = init.copy()
+
+        aff = affinity.PerplexityBasedNN(self.x)
+        embedding = TSNEEmbedding(init, aff)
+        embedding.optimize(10, inplace=True)
+
+        np.testing.assert_array_equal(init, init_copy)
+
+    def test_inplace_partial_embedding_optimization_doesnt_change_init(self):
+        embedding = TSNE(early_exaggeration_iter=10, n_iter=10).fit(self.x)
+
+        init = initialization.random(self.x_test)
+        init_copy = init.copy()
+
+        P = embedding.affinities.to_new(self.x_test)
+
+        partial_embedding = PartialTSNEEmbedding(init, embedding, P)
+        partial_embedding.optimize(10, inplace=True)
+
+        np.testing.assert_array_equal(init, init_copy)
+
+    def test_inplace_partial_embedding_optimization_doesnt_change_embedding(self):
+        embedding = TSNE(early_exaggeration_iter=10, n_iter=10).fit(self.x)
+        embedding_copy = np.array(embedding)
+
+        partial_embedding = embedding.prepare_partial(self.x_test)
+        partial_embedding.optimize(10, inplace=True)
+
+        np.testing.assert_array_equal(np.array(embedding), embedding_copy)
 
 
 class TestTSNECallbackParams(unittest.TestCase):

--- a/tests/test_tsne.py
+++ b/tests/test_tsne.py
@@ -958,13 +958,13 @@ class TestPrecomputedDistanceMatrices(unittest.TestCase):
             initialization="random",
             metric="precomputed",
             early_exaggeration_iter=0,
-            n_iter=0
+            n_iter=0,
         ).fit(d)
 
         knn = KNeighborsClassifier(n_neighbors=10)
         knn.fit(embedding, y)
         predictions = knn.predict(embedding)
-        self.assertLess(accuracy_score(predictions, y), 0.55)
+        self.assertLess(accuracy_score(predictions, y), 0.6)
 
 
 class TestMisc(unittest.TestCase):


### PR DESCRIPTION
##### Issue
In some forms of usage, the initialization was changed, which is incorrect.


##### Description of changes
Copy the intialization when constructing `TSNEEmbedding` and `PartialTSNEEmbedding` objects. This only happens once, so the memory impact should be minimal.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
