### PR TITLE
Auto early exaggeration to prevent collapse for small datasets

### DIFF
--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -330,6 +330,6 @@ class TestEarlyExaggerationCollapse(unittest.TestCase):
                 x = np.random.randn(n, p)
                 
                 # Only running early exaggeration, with default parameters
-                embedding = openTSNE(n_iter=0, random_state=42).fit(x)
+                embedding = openTSNE.TSNE(n_iter=0, random_state=42).fit(x)
                 self.assertGreater(np.max(np.abs(embedding)), 1e-10)
 

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -318,3 +318,18 @@ class TestSpectralInitializationCorrectness(unittest.TestCase):
         np.testing.assert_almost_equal(
             np.abs(np.corrcoef(embedding1[:,1], embedding2[:,1])[0,1]), 1
         )
+
+class TestEarlyExaggerationCollapse(unittest.TestCase):
+    def test_early_exaggeration_does_not_collapse(self):
+        ns = [100, 150, 200]
+        ps = [5, 10, 20]
+        
+        np.random.seed(42)
+        for n in ns:
+            for p in ps:
+                x = np.random.randn(n, p)
+                
+                # Only running early exaggeration, with default parameters
+                embedding = openTSNE(n_iter=0, random_state=42).fit(x)
+                self.assertGreater(np.max(np.abs(embedding)), 1e-10)
+

--- a/tests/test_different_usages.py
+++ b/tests/test_different_usages.py
@@ -196,7 +196,7 @@ class TestUsageExplicitOptimizeCalls(TestUsage):
         A = affinity.PerplexityBasedNN(self.x)
         I = initialization.pca(self.x, random_state=42)
         embedding2 = TSNEEmbedding(I, A)
-        embedding2 = embedding2.optimize(n_iter=25, exaggeration=12)
+        embedding2 = embedding2.optimize(n_iter=25, exaggeration=4)
         embedding2 = embedding2.optimize(n_iter=50)
         
         np.testing.assert_array_equal(


### PR DESCRIPTION
Should fix #233 (in a way). The idea is to set the default early exaggeration to 4 for small-ish (n<10k) datasets, following the original t-SNE paper. I am adding a test that checks if the early exaggeration leads to collapse for small structure-less datasets.

(Am going to push only the test at first, to see if it fails on the current master branch.) 