### PR TITLE
Fix BH collapse

### DIFF
--- a/openTSNE/quad_tree.pyx
+++ b/openTSNE/quad_tree.pyx
@@ -124,7 +124,7 @@ cdef void split_node(Node * node):
     PyMem_Free(new_center)
 
 
-cdef inline bint is_duplicate(Node * node, double * point, double duplicate_eps=1e-6) nogil:
+cdef inline bint is_duplicate(Node * node, double * point, double duplicate_eps=EPSILON) nogil:
     cdef Py_ssize_t d
     for d in range(node.n_dims):
         if fabs(node.center_of_mass[d] - point[d]) >= duplicate_eps:

--- a/openTSNE/quad_tree.pyx
+++ b/openTSNE/quad_tree.pyx
@@ -124,7 +124,7 @@ cdef void split_node(Node * node):
     PyMem_Free(new_center)
 
 
-cdef inline bint is_duplicate(Node * node, double * point, double duplicate_eps=EPSILON) nogil:
+cdef inline bint is_duplicate(Node * node, double * point, double duplicate_eps=1e-16) nogil:
     cdef Py_ssize_t d
     for d in range(node.n_dims):
         if fabs(node.center_of_mass[d] - point[d]) >= duplicate_eps:

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -318,3 +318,18 @@ class TestSpectralInitializationCorrectness(unittest.TestCase):
         np.testing.assert_almost_equal(
             np.abs(np.corrcoef(embedding1[:,1], embedding2[:,1])[0,1]), 1
         )
+
+
+class TestEarlyExaggerationCollapse(unittest.TestCase):
+    """In some cases, the BH implementation was producing a collapsed embedding
+    for all data points. For more information, see #233, #234."""
+    def test_early_exaggeration_does_not_collapse(self):
+        n_samples = [100, 150, 200]
+        n_dims = [5, 10, 20]
+
+        np.random.seed(42)
+        for n in n_samples:
+            for d in n_dims:
+                x = np.random.randn(n, d)
+                embedding = openTSNE.TSNE(random_state=42).fit(x)
+                self.assertGreater(np.max(np.abs(embedding)), 1e-8)


### PR DESCRIPTION
##### Issue
Fixes #223.

The `is_duplicate` function in the BH implementation had a threshold set to 1e-6, likely taken from other implementations, perhaps scikit-learn. This meant that during the EE phase, where everything was squished together, this condition was triggered a lot, meaning BH wasn't splitting up the points into different quadrants, but was pretending it was dealing with a single point. This mean that there were no repulsive forces being applied to the points at all, leading to an increasing collapse of all the points.

##### Description of changes
I simply changed the threshold for duplicate detection to machine precision, and the issue goes away.
I also copied over the test by @dkobak from #234, but I've also let it run the standard phase. We want to make sure that the embedding isn't collapsed at the end of the optimization, and we don't really care if it is super compressed at the end of the EE phase.

**EDIT**: Not machine precision, because then, duplicate detection actually doesn't work, and the tests fail on iris. Setting the threshold to 1e-16 resolves both issues.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
