### PR TITLE
Implement binary uniform affinity

### DIFF
--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -1197,6 +1197,12 @@ class Uniform(Affinities):
             P = (P + P.T > 0).astype(float)
         elif symmetrize == "mean":
             P = (P + P.T) / 2
+        elif symmetrize == False:
+            pass
+        else:
+            raise ValueError(
+                f"Symmetrization method ({symmetrize}) is not recognized."
+            )
 
         # Convert weights to probabilities
         P /= np.sum(P)

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -1113,10 +1113,12 @@ class Uniform(Affinities):
 
     symmetrize: Union[str, bool]
         Symmetrize affinity matrix. Standard t-SNE symmetrizes the interactions
-        but when embedding new data, symmetrization is not performed. Default value is True
-        and is equivalent to ``average``: symmetrization via (A + A.T)/2. Alternatively,
-        ``or`` yields a binary affinity matrix with all non-zero elements being the same:
-        (A + A.T) > 0.
+        but when embedding new data, symmetrization is not performed. Default value is
+        ``max`` and yields a binary affinity matrix with all non-zero elements
+        (corresponding to edges of the kNN graph) being the same. Another
+        possibility is ``mean``, which performs symmetrization via (A + A.T)/2, resulting
+        in the affinity matrix with two possible non-zero values. ``True`` is equivalent
+        to ``max``. ``False`` performs no symmetrization.
 
     n_jobs: int
         The number of threads to use while running t-SNE. This follows the
@@ -1145,7 +1147,7 @@ class Uniform(Affinities):
         method="auto",
         metric="euclidean",
         metric_params=None,
-        symmetrize=True,
+        symmetrize="max",
         n_jobs=1,
         random_state=None,
         verbose=False,
@@ -1191,9 +1193,9 @@ class Uniform(Affinities):
         )
 
         # Symmetrize the probability matrix
-        if symmetrize == "or":
+        if symmetrize == "max" or symmetrize == True:
             P = (P + P.T > 0).astype(float)
-        elif symmetrize == "average" or symmetrize == True:
+        elif symmetrize == "mean":
             P = (P + P.T) / 2
 
         # Convert weights to probabilities

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -1111,9 +1111,12 @@ class Uniform(Affinities):
     metric_params: dict
         Additional keyword arguments for the metric function.
 
-    symmetrize: bool
+    symmetrize: Union[str, bool]
         Symmetrize affinity matrix. Standard t-SNE symmetrizes the interactions
-        but when embedding new data, symmetrization is not performed.
+        but when embedding new data, symmetrization is not performed. Default value is True
+        and is equivalent to ``average``: symmetrization via (A + A.T)/2. Alternatively,
+        ``or`` yields a binary affinity matrix with all non-zero elements being the same:
+        (A + A.T) > 0.
 
     n_jobs: int
         The number of threads to use while running t-SNE. This follows the
@@ -1188,7 +1191,9 @@ class Uniform(Affinities):
         )
 
         # Symmetrize the probability matrix
-        if symmetrize:
+        if symmetrize == "or":
+            P = (P + P.T > 0).astype(float)
+        elif symmetrize == "average" or symmetrize == True:
             P = (P + P.T) / 2
 
         # Convert weights to probabilities

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -11,6 +11,8 @@ from openTSNE import nearest_neighbors
 from openTSNE import utils
 from openTSNE.utils import is_package_installed
 
+import warnings
+
 log = logging.getLogger(__name__)
 
 
@@ -1113,12 +1115,14 @@ class Uniform(Affinities):
 
     symmetrize: Union[str, bool]
         Symmetrize affinity matrix. Standard t-SNE symmetrizes the interactions
-        but when embedding new data, symmetrization is not performed. Default value is
-        ``max`` and yields a binary affinity matrix with all non-zero elements
-        (corresponding to edges of the kNN graph) being the same. Another
-        possibility is ``mean``, which performs symmetrization via (A + A.T)/2, resulting
-        in the affinity matrix with two possible non-zero values. ``True`` is equivalent
-        to ``max``. ``False`` performs no symmetrization.
+        but when embedding new data, symmetrization is not performed. Available options
+        are ``max``, ``mean``, and ``none``.
+        ``max`` yields a binary affinity matrix with all non-zero elements
+        (corresponding to edges of the kNN graph) being the same. ``mean`` performs
+        symmetrization via (A + A.T)/2, resulting in the affinity matrix with two possible
+        non-zero values. ``none`` results in non-symmetric affinity matrix. Default value
+        is ``True`` which is equivalent to ``mean``, but the default will change to
+        ``max`` in future versions.
 
     n_jobs: int
         The number of threads to use while running t-SNE. This follows the
@@ -1147,7 +1151,7 @@ class Uniform(Affinities):
         method="auto",
         metric="euclidean",
         metric_params=None,
-        symmetrize="max",
+        symmetrize=True,
         n_jobs=1,
         random_state=None,
         verbose=False,
@@ -1193,12 +1197,20 @@ class Uniform(Affinities):
         )
 
         # Symmetrize the probability matrix
-        if symmetrize == "max" or symmetrize == True:
+        if symmetrize == "max":
             P = (P + P.T > 0).astype(float)
         elif symmetrize == "mean":
             P = (P + P.T) / 2
-        elif symmetrize == False:
+        elif symmetrize == "none":
             pass
+        elif symmetrize == True:
+            # Backward compatibility
+            P = (P + P.T) / 2
+            warnings.warn(
+                f"Using `mean` symmetrization, but the default behaviour is going to "
+                f"change to `max` in future versions.",
+                category=FutureWarning,
+            )
         else:
             raise ValueError(
                 f"Symmetrization method ({symmetrize}) is not recognized."

--- a/openTSNE/affinity.py
+++ b/openTSNE/affinity.py
@@ -1122,7 +1122,7 @@ class Uniform(Affinities):
         symmetrization via (A + A.T)/2, resulting in the affinity matrix with two possible
         non-zero values. ``none`` results in non-symmetric affinity matrix. Default value
         is ``True`` which is equivalent to ``mean``, but the default will change to
-        ``max`` in future versions.
+        ``max`` in future versions. ``False`` is equivalent to ``none``.
 
     n_jobs: int
         The number of threads to use while running t-SNE. This follows the
@@ -1201,7 +1201,7 @@ class Uniform(Affinities):
             P = (P + P.T > 0).astype(float)
         elif symmetrize == "mean":
             P = (P + P.T) / 2
-        elif symmetrize == "none":
+        elif symmetrize == "none" or symmetrize == False:
             pass
         elif symmetrize == True:
             # Backward compatibility


### PR DESCRIPTION
This is a very minor suggestion, but I realized some time ago that in some papers we implement "uniform affinities" slightly differently: not as `(P + P.T) / 2` but as `(P + P.T > 0).astype(float)` where `P` is the kNN adjacency matrix. The only difference is that the former has two possible non-zero values, whereas the latter has only one possible non-zero value, which is kind of neat.

This does not really make much of a different in practice, but I thought it may be nice to implement it in `Uniform()` using `symmetrize="average"` and `symmetrize="or"`, in addition to `symmetrize=True/False` which this class has anyway.

![tsne-uniform-two-kinds](https://github.com/pavlin-policar/openTSNE/assets/8970231/50f0ba1b-3097-4ab9-bbab-dfb3d42ad04f)
