### PR TITLE
setup.py maintenance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ setup(
     ],
 
     packages=setuptools.find_packages(include=["openTSNE", "openTSNE.*"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "numpy>=1.16.6",
         "scikit-learn>=0.20",

--- a/setup.py
+++ b/setup.py
@@ -55,16 +55,9 @@ class ConvertNotebooksToDocs(distutils.cmd.Command):
             writer.write(body, resources, nb_name)
 
 
-class get_numpy_include:
-    """Helper class to determine the numpy include path
-
-    The purpose of this class is to postpone importing numpy until it is
-    actually installed, so that the ``get_include()`` method can be invoked.
-
-    """
-    def __str__(self):
-        import numpy
-        return numpy.get_include()
+def get_numpy_include():
+    import numpy
+    return numpy.get_include()
 
 
 def get_include_dirs():

--- a/setup.py
+++ b/setup.py
@@ -289,9 +289,6 @@ setup(
         "scikit-learn>=0.20",
         "scipy",
     ],
-    setup_requires=[
-        "cython",
-    ],
     extras_require={
         "hnsw": "hnswlib~=0.4.0",
         "pynndescent": "pynndescent~=0.5.0",

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ class CythonBuildExt(build_ext):
             if platform.machine() == "x86_64":
                 extra_compile_args += ["-march=native"]
 
-        # We will disable openmp flags if the compiler doesn"t support it. This
+        # We will disable openmp flags if the compiler doesn't support it. This
         # is only really an issue with OSX clang
         if has_c_library("omp"):
             print("Found openmp. Compiling with openmp flags...")

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,8 @@ from distutils.sysconfig import customize_compiler
 from os.path import join
 
 import setuptools
+from Cython.Distutils.build_ext import new_build_ext as build_ext
 from setuptools import setup, Extension
-
-try:
-    from Cython.Distutils.build_ext import new_build_ext as build_ext
-    have_cython = True
-except ImportError:
-    have_cython = False
 
 
 class ConvertNotebooksToDocs(distutils.cmd.Command):
@@ -119,9 +114,6 @@ def has_c_library(library, extension=".c"):
 
 class CythonBuildExt(build_ext):
     def build_extensions(self):
-        if not have_cython:
-            raise RuntimeError("Missing build dependency: Cython")
-
         extra_compile_args = []
         extra_link_args = []
 


### PR DESCRIPTION
##### Issue
It seems that in the latest version of `pip`, we can no longer pass in a class into `include_dirs` that eventually resolves into a string. This was previously done because running `setup.py` in a fresh environment would fail as numpy had not yet been installed. Therefore, we used a utility `get_numpy_include` class which would import numpy only when it was called, after numpy was already installed. This is apparently no longer supported.

Related issue: #248
Failing tests in PR #246

##### Description of changes
This is most likely no longer needed because we now build using `pyproject.toml`, where we can pre-specify the build requirements, which will always be installed before the `setup.py` script is run. Therefore, we no longer need any checks if numpy is installed.
Similarly, the `have_cython` check is no longer needed in `setup.py` either, as we specify cython as a build dependency in `pyproject.toml`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
