### PR TITLE
Build python 3.12 wheels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ openTSNE is a modular Python implementation of t-Distributed Stochasitc Neighbor
 Installation
 ------------
 
-openTSNE requires Python 3.7 or higher in order to run.
+openTSNE requires Python 3.8 or higher in order to run.
 
 Conda
 ~~~~~

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -18,11 +18,6 @@ jobs:
 
     strategy:
       matrix:
-        osx - python37:
-          image.name: 'macos-12'
-          python.version: '3.7'
-          ciwb.build: cp37-macosx_x86_64
-          ciwb.archs: x86_64
         osx - python38:
           image.name: 'macos-12'
           python.version: '3.8'
@@ -43,12 +38,12 @@ jobs:
           python.version: '3.11'
           ciwb.build: cp311-macosx_universal2
           ciwb.archs: universal2
+        osx - python312:
+          image.name: 'macos-12'
+          python.version: '3.12'
+          ciwb.build: cp312-macosx_universal2
+          ciwb.archs: universal2
 
-        windows - python37:
-          image.name: 'windows-2019'
-          python.version: '3.7'
-          ciwb.build: cp37-win_amd64
-          ciwb.archs: AMD64
         windows - python38:
           image.name: 'windows-2019'
           python.version: '3.8'
@@ -68,6 +63,11 @@ jobs:
           image.name: 'windows-2019'
           python.version: '3.11'
           ciwb.build: cp311-win_amd64
+          ciwb.archs: AMD64
+        windows - python312:
+          image.name: 'windows-2019'
+          python.version: '3.12'
+          ciwb.build: cp312-win_amd64
           ciwb.archs: AMD64
 
     steps:
@@ -138,9 +138,6 @@ jobs:
 
     strategy:
       matrix:
-        python37:
-          python: '/opt/python/cp37-cp37m/bin'
-          python.version: '3.7'
         python38:
           python: '/opt/python/cp38-cp38/bin'
           python.version: '3.8'
@@ -153,6 +150,9 @@ jobs:
         python311:
           python: '/opt/python/cp311-cp311/bin'
           python.version: '3.11'
+        python312:
+          python: '/opt/python/cp312-cp312/bin'
+          python.version: '3.12'
 
     container:
       image: quay.io/pypa/manylinux2014_x86_64:latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,9 +13,6 @@ jobs:
 
   strategy:
     matrix:
-      linux-python37:
-        image.name: 'ubuntu-latest'
-        python.version: '3.7'
       linux-python38:
         image.name: 'ubuntu-latest'
         python.version: '3.8'
@@ -28,9 +25,9 @@ jobs:
       linux-python311:
         image.name: 'ubuntu-latest'
         python.version: '3.11'
-      osx-python37:
-        image.name: 'macos-12'
-        python.version: '3.7'
+      linux-python312:
+        image.name: 'ubuntu-latest'
+        python.version: '3.12'
       osx-python38:
         image.name: 'macos-12'
         python.version: '3.8'
@@ -43,9 +40,9 @@ jobs:
       osx-python311:
         image.name: 'macos-12'
         python.version: '3.11'
-      windows-python37:
-        image.name: 'windows-2019'
-        python.version: '3.7'
+      osx-python312:
+        image.name: 'macos-12'
+        python.version: '3.12'
       windows-python38:
         image.name: 'windows-2019'
         python.version: '3.8'
@@ -58,6 +55,9 @@ jobs:
       windows-python311:
         image.name: 'windows-2019'
         python.version: '3.11'
+      windows-python312:
+        image.name: 'windows-2019'
+        python.version: '3.12'
 
   steps:
   - task: UsePythonVersion@0

--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ setup(
     ],
 
     packages=setuptools.find_packages(include=["openTSNE", "openTSNE.*"]),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "numpy>=1.16.6",
         "scikit-learn>=0.20",


### PR DESCRIPTION
##### Issue
Wheels for Python 3.12 are missing.

##### Description of changes
- Updating workflow to build wheels for Python 3.12
- Removing building wheels for Python 3.7 which is already out-of-life

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
