### PR TITLE
Switch to tempfile.NamedTemporaryFile

### DIFF
--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -338,7 +338,7 @@ class Annoy(KNNIndex):
         if self.index is not None:
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
                 self.index.save(tmp.name)
-                # tmp.close() # Just trying out if maybe it's closed already
+                # tmp.close() # Windows test fails independent of including/excluding this line
 
                 with open(tmp.name, "rb") as f:
                     b64_index = base64.b64encode(f.read())
@@ -373,7 +373,6 @@ class Annoy(KNNIndex):
 
             self.index = AnnoyIndex(state["data"].shape[1], annoy_metric)
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-                # with open(tmp.name, "wb") as f:
                 tmp.write(base64.b64decode(b64_index))
                 tmp.close()
                 
@@ -709,7 +708,6 @@ class HNSW(KNNIndex):
 
             self.index = Index(space=hnsw_metric, dim=state["data"].data.shape[1])
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-                # with open(tmp.name, "wb") as f:
                 tmp.write(base64.b64decode(b64_index))
                 tmp.close()
                 

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -338,6 +338,7 @@ class Annoy(KNNIndex):
         if self.index is not None:
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
                 self.index.save(tmp.name)
+                tmp.close()
 
                 with open(tmp.name, "rb") as f:
                     b64_index = base64.b64encode(f.read())
@@ -372,8 +373,8 @@ class Annoy(KNNIndex):
 
             self.index = AnnoyIndex(state["data"].shape[1], annoy_metric)
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-                with open(tmp.name, "wb") as f:
-                    f.write(base64.b64decode(b64_index))
+                # with open(tmp.name, "wb") as f:
+                tmp.write(base64.b64decode(b64_index))
                 self.index.load(tmp.name)
 
         self.__dict__.update(state)
@@ -670,6 +671,7 @@ class HNSW(KNNIndex):
         if self.index is not None:
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
                 self.index.save_index(tmp.name)
+                tmp.close()
 
                 with open(tmp.name, "rb") as f:
                     b64_index = base64.b64encode(f.read())
@@ -705,8 +707,8 @@ class HNSW(KNNIndex):
 
             self.index = Index(space=hnsw_metric, dim=state["data"].data.shape[1])
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-                with open(tmp.name, "wb") as f:
-                    f.write(base64.b64decode(b64_index))
+                # with open(tmp.name, "wb") as f:
+                tmp.write(base64.b64decode(b64_index))
                 self.index.load_index(tmp.name)
 
         self.__dict__.update(state)

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -668,7 +668,7 @@ class HNSW(KNNIndex):
         d = dict(self.__dict__)
         # If the index is not None, we want to save the encoded index
         if self.index is not None:
-            with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+            with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
                 self.index.save_index(tmp.name)
 
                 with open(tmp.name, "rb") as f:
@@ -704,7 +704,7 @@ class HNSW(KNNIndex):
                 hnsw_metric = hnsw_aliases[hnsw_metric]
 
             self.index = Index(space=hnsw_metric, dim=state["data"].data.shape[1])
-            with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+            with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
                 with open(tmp.name, "wb") as f:
                     f.write(base64.b64decode(b64_index))
                 self.index.load_index(tmp.name)

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -375,6 +375,8 @@ class Annoy(KNNIndex):
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
                 # with open(tmp.name, "wb") as f:
                 tmp.write(base64.b64decode(b64_index))
+                tmp.close()
+                
                 self.index.load(tmp.name)
 
         self.__dict__.update(state)
@@ -709,6 +711,8 @@ class HNSW(KNNIndex):
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
                 # with open(tmp.name, "wb") as f:
                 tmp.write(base64.b64decode(b64_index))
+                tmp.close()
+                
                 self.index.load_index(tmp.name)
 
         self.__dict__.update(state)

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -336,10 +336,10 @@ class Annoy(KNNIndex):
         d = dict(self.__dict__)
         # If the index is not None, we want to save the encoded index
         if self.index is not None:
-            with tempfile.TemporaryDirectory() as dirname:
-                self.index.save(path.join(dirname, "tmp.ann"))
+            with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+                self.index.save(tmp.name)
 
-                with open(path.join(dirname, "tmp.ann"), "rb") as f:
+                with open(tmp.name, "rb") as f:
                     b64_index = base64.b64encode(f.read())
 
             d["b64_index"] = b64_index
@@ -668,10 +668,10 @@ class HNSW(KNNIndex):
         d = dict(self.__dict__)
         # If the index is not None, we want to save the encoded index
         if self.index is not None:
-            with tempfile.TemporaryDirectory() as dirname:
-                self.index.save_index(path.join(dirname, "tmp.bin"))
+            with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+                self.index.save_index(tmp.name)
 
-                with open(path.join(dirname, "tmp.bin"), "rb") as f:
+                with open(tmp.name, "rb") as f:
                     b64_index = base64.b64encode(f.read())
 
             d["b64_index"] = b64_index
@@ -704,10 +704,10 @@ class HNSW(KNNIndex):
                 hnsw_metric = hnsw_aliases[hnsw_metric]
 
             self.index = Index(space=hnsw_metric, dim=state["data"].data.shape[1])
-            with tempfile.TemporaryDirectory() as dirname:
-                with open(path.join(dirname, "tmp.bin"), "wb") as f:
+            with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+                with open(tmp.name, "wb") as f:
                     f.write(base64.b64decode(b64_index))
-                self.index.load_index(path.join(dirname, "tmp.bin"))
+                self.index.load_index(tmp.name)
 
         self.__dict__.update(state)
 

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -336,7 +336,7 @@ class Annoy(KNNIndex):
         d = dict(self.__dict__)
         # If the index is not None, we want to save the encoded index
         if self.index is not None:
-            with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+            with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
                 self.index.save(tmp.name)
 
                 with open(tmp.name, "rb") as f:
@@ -371,10 +371,10 @@ class Annoy(KNNIndex):
                 annoy_metric = annoy_aliases[annoy_metric]
 
             self.index = AnnoyIndex(state["data"].shape[1], annoy_metric)
-            with tempfile.TemporaryDirectory() as dirname:
-                with open(path.join(dirname, "tmp.ann"), "wb") as f:
+            with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
+                with open(tmp.name, "wb") as f:
                     f.write(base64.b64decode(b64_index))
-                self.index.load(path.join(dirname, "tmp.ann"))
+                self.index.load(tmp.name)
 
         self.__dict__.update(state)
 

--- a/openTSNE/nearest_neighbors.py
+++ b/openTSNE/nearest_neighbors.py
@@ -338,7 +338,7 @@ class Annoy(KNNIndex):
         if self.index is not None:
             with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
                 self.index.save(tmp.name)
-                tmp.close()
+                # tmp.close() # Just trying out if maybe it's closed already
 
                 with open(tmp.name, "rb") as f:
                     b64_index = base64.b64encode(f.read())

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -94,8 +94,9 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
         self.assertIsNone(knn_index.index)
 
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            with open(tmp.name, "wb") as f:
-                pickle.dump(knn_index, f)
+            # with open(tmp.name, "wb") as f:
+            pickle.dump(knn_index, tmp)
+            tmp.close()
 
             with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
@@ -106,8 +107,9 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            with open(tmp.name, "wb") as f:
-                pickle.dump(knn_index, f)
+            # with open(tmp.name, "wb") as f:
+            pickle.dump(knn_index, tmp)
+            tmp.close()
 
             with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
@@ -121,8 +123,9 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
         self.assertIsNotNone(knn_index.index)
 
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            with open(tmp.name, "wb") as f:
-                pickle.dump(knn_index, f)
+            # with open(tmp.name, "wb") as f:
+            pickle.dump(knn_index, tmp)
+            tmp.close()
 
             with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
@@ -249,8 +252,9 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
         self.assertIsNone(knn_index.index)
 
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            with open(tmp.name, "wb") as f:
-                pickle.dump(knn_index, f)
+            # with open(tmp.name, "wb") as f:
+            pickle.dump(knn_index, tmp)
+            tmp.close()
 
             with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
@@ -261,8 +265,9 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            with open(tmp.name, "wb") as f:
-                pickle.dump(knn_index, f)
+            # with open(tmp.name, "wb") as f:
+            pickle.dump(knn_index, tmp)
+            tmp.close()
 
             with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
@@ -276,8 +281,9 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
         self.assertIsNotNone(knn_index.index)
 
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            with open(tmp.name, "wb") as f:
-                pickle.dump(knn_index, f)
+            # with open(tmp.name, "wb") as f:
+            pickle.dump(knn_index, tmp)
+            tmp.close()
 
             with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -93,7 +93,7 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
         self.assertIsNone(knn_index.index)
 
-        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+        with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
             with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
@@ -105,7 +105,7 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
     @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
-        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+        with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
             with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
@@ -120,7 +120,7 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
         knn_index.build()
         self.assertIsNotNone(knn_index.index)
 
-        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+        with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
             with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
@@ -248,7 +248,7 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
         self.assertIsNone(knn_index.index)
 
-        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+        with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
             with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
@@ -260,7 +260,7 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
     @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
-        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+        with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
             with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
@@ -275,7 +275,7 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
         knn_index.build()
         self.assertIsNotNone(knn_index.index)
 
-        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+        with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
             with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -88,7 +88,7 @@ class KNNIndexTestMixin:
 class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
     knn_index = nearest_neighbors.Annoy
 
-    @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
+    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index(self):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
         self.assertIsNone(knn_index.index)
@@ -102,7 +102,7 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
 
         self.assertIsNone(loaded_obj.index)
 
-    @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
+    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
@@ -114,7 +114,7 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
 
         self.assertIsNone(loaded_obj.index)
 
-    @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
+    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_with_built_index(self):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
         knn_index.build()
@@ -243,7 +243,7 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
         global hnswlib
         import hnswlib
 
-    @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
+    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index(self):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
         self.assertIsNone(knn_index.index)
@@ -257,7 +257,7 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
 
         self.assertIsNone(loaded_obj.index)
 
-    @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
+    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
@@ -269,7 +269,7 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
 
         self.assertIsNone(loaded_obj.index)
 
-    @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
+    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_with_built_index(self):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
         knn_index.build()

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -93,11 +93,11 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
         self.assertIsNone(knn_index.index)
 
-        with tempfile.TemporaryDirectory() as dirname:
-            with open(path.join(dirname, "index.pkl"), "wb") as f:
+        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+            with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
-            with open(path.join(dirname, "index.pkl"), "rb") as f:
+            with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
 
         self.assertIsNone(loaded_obj.index)
@@ -105,11 +105,11 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
     @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
-        with tempfile.TemporaryDirectory() as dirname:
-            with open(path.join(dirname, "index.pkl"), "wb") as f:
+        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+            with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
-            with open(path.join(dirname, "index.pkl"), "rb") as f:
+            with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
 
         self.assertIsNone(loaded_obj.index)
@@ -120,11 +120,11 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
         knn_index.build()
         self.assertIsNotNone(knn_index.index)
 
-        with tempfile.TemporaryDirectory() as dirname:
-            with open(path.join(dirname, "index.pkl"), "wb") as f:
+        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+            with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
-            with open(path.join(dirname, "index.pkl"), "rb") as f:
+            with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
 
         load_idx, load_dist = loaded_obj.query(self.iris, 15)
@@ -248,11 +248,11 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
         self.assertIsNone(knn_index.index)
 
-        with tempfile.TemporaryDirectory() as dirname:
-            with open(path.join(dirname, "index.pkl"), "wb") as f:
+        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+            with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
-            with open(path.join(dirname, "index.pkl"), "rb") as f:
+            with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
 
         self.assertIsNone(loaded_obj.index)
@@ -260,11 +260,11 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
     @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
-        with tempfile.TemporaryDirectory() as dirname:
-            with open(path.join(dirname, "index.pkl"), "wb") as f:
+        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+            with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
-            with open(path.join(dirname, "index.pkl"), "rb") as f:
+            with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
 
         self.assertIsNone(loaded_obj.index)
@@ -275,11 +275,11 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
         knn_index.build()
         self.assertIsNotNone(knn_index.index)
 
-        with tempfile.TemporaryDirectory() as dirname:
-            with open(path.join(dirname, "index.pkl"), "wb") as f:
+        with tempfile.TemporaryFile(delete_on_close=False) as tmp:
+            with open(tmp.name, "wb") as f:
                 pickle.dump(knn_index, f)
 
-            with open(path.join(dirname, "index.pkl"), "rb") as f:
+            with open(tmp.name, "rb") as f:
                 loaded_obj = pickle.load(f)
 
         load_idx, load_dist = loaded_obj.query(self.iris, 15)

--- a/tests/test_nearest_neighbors.py
+++ b/tests/test_nearest_neighbors.py
@@ -88,13 +88,11 @@ class KNNIndexTestMixin:
 class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
     knn_index = nearest_neighbors.Annoy
 
-    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index(self):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
         self.assertIsNone(knn_index.index)
 
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            # with open(tmp.name, "wb") as f:
             pickle.dump(knn_index, tmp)
             tmp.close()
 
@@ -103,11 +101,9 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
 
         self.assertIsNone(loaded_obj.index)
 
-    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            # with open(tmp.name, "wb") as f:
             pickle.dump(knn_index, tmp)
             tmp.close()
 
@@ -116,14 +112,12 @@ class TestAnnoy(KNNIndexTestMixin, unittest.TestCase):
 
         self.assertIsNone(loaded_obj.index)
 
-    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_with_built_index(self):
         knn_index = nearest_neighbors.Annoy(self.iris, k=30)
         knn_index.build()
         self.assertIsNotNone(knn_index.index)
 
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            # with open(tmp.name, "wb") as f:
             pickle.dump(knn_index, tmp)
             tmp.close()
 
@@ -246,13 +240,11 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
         global hnswlib
         import hnswlib
 
-    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index(self):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
         self.assertIsNone(knn_index.index)
 
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            # with open(tmp.name, "wb") as f:
             pickle.dump(knn_index, tmp)
             tmp.close()
 
@@ -261,11 +253,9 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
 
         self.assertIsNone(loaded_obj.index)
 
-    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_without_built_index_cleans_up_fname(self):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            # with open(tmp.name, "wb") as f:
             pickle.dump(knn_index, tmp)
             tmp.close()
 
@@ -274,14 +264,12 @@ class TestHNSW(KNNIndexTestMixin, unittest.TestCase):
 
         self.assertIsNone(loaded_obj.index)
 
-    # @unittest.skipIf(platform.system() == "Windows", "Files locked on Windows")
     def test_pickle_with_built_index(self):
         knn_index = nearest_neighbors.HNSW(self.iris, k=30)
         knn_index.build()
         self.assertIsNotNone(knn_index.index)
 
         with tempfile.NamedTemporaryFile(delete_on_close=False) as tmp:
-            # with open(tmp.name, "wb") as f:
             pickle.dump(knn_index, tmp)
             tmp.close()
 


### PR DESCRIPTION
Trying to fix #210 as discussed there.

See https://docs.python.org/3.12/library/tempfile.html#examples for an official example of how to work with `NamedTemporaryFile` when one needs to write smth into it and then read from it:

```Python
# create a temporary file using a context manager
# close the file, use the name to open the file again

with tempfile.NamedTemporaryFile(delete_on_close=False) as fp:
    fp.write(b'Hello world!')
    fp.close()
    # the file is closed, but not removed
    
    # open the file again by using its name
    with open(fp.name, mode='rb') as f:
        f.read()
# file is now removed